### PR TITLE
[ENH] Push user QC to XNAT's usability fields

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -5,3 +5,4 @@ from .oauth import *
 from .scheduler import *
 from .logging import *
 from .cluster import *
+from .xnat import *

--- a/config/xnat.py
+++ b/config/xnat.py
@@ -1,0 +1,18 @@
+"""Configuration for XNAT integration
+"""
+import os
+
+from .utils import read_boolean
+
+XNAT_ENABLED = read_boolean('DASH_ENABLE_XNAT')
+
+# These can be omitted as long as an XnatCredentials file was configured
+# in the datman configuration files
+XNAT_USER = os.environ.get('XNAT_USER')
+XNAT_PASS = os.environ.get('XNAT_PASS')
+
+# If one or the other is defined, both must be
+if XNAT_ENABLED and (XNAT_USER or XNAT_PASS) and not (XNAT_USER and XNAT_PASS):
+    logger.error("XNAT_USER or XNAT_PASS undefined, xnat integration will "
+                 "be disabled.")
+    XNAT_ENABLED = False

--- a/config/xnat.py
+++ b/config/xnat.py
@@ -1,8 +1,11 @@
 """Configuration for XNAT integration
 """
+import logging
 import os
 
 from .utils import read_boolean
+
+logger = logging.getLogger(__name__)
 
 XNAT_ENABLED = read_boolean('DASH_ENABLE_XNAT')
 

--- a/containers/devel/dashboard.env
+++ b/containers/devel/dashboard.env
@@ -87,5 +87,6 @@ LOGIN_DISABLED=True
 
 # XNAT
 # ----
+# DASH_ENABLE_XNAT=False
 # XNAT_USER=
 # XNAT_PASS=

--- a/containers/prod/dashboard.env
+++ b/containers/prod/dashboard.env
@@ -87,5 +87,6 @@ POSTGRES_DATABASE=dashboard
 
 # XNAT
 # ----
+# DASH_ENABLE_XNAT=False
 # XNAT_USER=
 # XNAT_PASS=

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1512,7 +1512,7 @@ class Scan(db.Model):
         checklist.update_entry(signing_user, comment, sign_off)
         checklist.save()
         if current_app.config.get('XNAT_ENABLED'):
-            utils.update_xnat_usability(self, current_app)
+            utils.update_xnat_usability(self, current_app.config)
 
     def is_linked(self):
         return self.source_id is not None

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 from random import randint
 
+from flask import current_app
 from flask_login import UserMixin
 from sqlalchemy import and_, or_, exists, func
 from sqlalchemy.dialects.postgresql import JSONB
@@ -1510,6 +1511,8 @@ class Scan(db.Model):
             checklist = self._new_checklist_entry(signing_user)
         checklist.update_entry(signing_user, comment, sign_off)
         checklist.save()
+        if current_app.config.get('XNAT_ENABLED'):
+            utils.update_xnat_usability(self, current_app)
 
     def is_linked(self):
         return self.source_id is not None

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -2055,6 +2055,11 @@ class StudySite(db.Model):
     code = db.Column('code', db.String(32))
     download_script = db.Column('download_script', db.String(128))
     post_download_script = db.Column('post_download_script', db.String(128))
+    xnat_server = db.Column('xnat_server', db.String(128))
+    xnat_port = db.Column('xnat_port', db.Integer)
+    xnat_archive = db.Column('xnat_archive', db.String(32))
+    xnat_convention = db.Column('xnat_convention', db.String(10))
+    xnat_credentials = db.Column('xnat_credentials', db.String(128))
 
     # Need to specify the terms of the join to ensure users with
     # access to all sites dont get left out of the list for a specific site

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -2058,10 +2058,11 @@ class StudySite(db.Model):
     code = db.Column('code', db.String(32))
     download_script = db.Column('download_script', db.String(128))
     post_download_script = db.Column('post_download_script', db.String(128))
-    xnat_server = db.Column('xnat_server', db.String(128))
-    xnat_port = db.Column('xnat_port', db.Integer)
+    xnat_url = db.Column('xnat_url', db.String(128))
     xnat_archive = db.Column('xnat_archive', db.String(32))
-    xnat_convention = db.Column('xnat_convention', db.String(10))
+    xnat_convention = db.Column(
+        'xnat_convention', db.String(10), server_default='KCNI'
+    )
     xnat_credentials = db.Column('xnat_credentials', db.String(128))
 
     # Need to specify the terms of the join to ensure users with

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -99,7 +99,7 @@ def update_xnat_usability(scan, current_app):
         scan.session, site_settings.xnat_convention.lower() + "_name"
     )
     user, password = get_xnat_credentials(site_settings, current_app)
-    with xnat.connect(site_settings.xnat_server,
+    with xnat.connect(site_settings.xnat_url,
                       user=user,
                       password=password) as xcon:
         project = xcon.projects[site_settings.xnat_archive]

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -168,7 +168,7 @@ def async_xnat_update(xnat_url, user, password, xnat_archive, exp_name,
         password (str): The password to log in with.
         xnat_archvie (str): The name of the XNAT archive that contains the
             experiment.
-        exp_name (str); The name of the experiment on XNAT.
+        exp_name (str): The name of the experiment on XNAT.
         series_num (int): The series number of the file to update.
         comment (str): The user's QC comment.
         quality (str): The quality label to apply based on whether data

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -372,10 +372,13 @@ Configuration for the dashboard's job scheduler.
     
 XNAT
 ****
-Enable or disable the XNAT integration. A username and password to use when 
-logging in may be set here, or may be configured individually for each study 
-in the study config file. For more information see Datman's configuration 
-guide.
+Enable or disable the XNAT integration. Note that if you enable XNAT 
+configuration, you must ensure you have added the XNAT server settings to the 
+study_sites table of the database.
+
+A username and password to use when logging in may be set directly in the 
+dashboard, or may be configured individually for each study in the study config 
+file. For more information see Datman's configuration guide.
 
 Optional
 ^^^^^^^^

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -369,3 +369,27 @@ Configuration for the dashboard's job scheduler.
   
   * Description: The URL to send scheduler jobs to. This setting is needed 
     only by 'client' instances of the dashboard.
+    
+XNAT
+****
+Enable or disable the XNAT integration. A username and password to use when 
+logging in may be set here, or may be configured individually for each study 
+in the study config file. For more information see Datman's configuration 
+guide.
+
+Optional
+^^^^^^^^
+
+* **DASH_ENABLE_XNAT**
+
+  * Description: Controls whether XNAT features will be used.
+  * Accepted values: ``True`` or ``False``
+  * Default values: ``False``
+* **XNAT_USER**
+
+  * Description: May be used to provide an XNAT username if one is not set 
+    in the configuration files. If this is set, XNAT_PASS must be as well.
+* **XNAT_PASS**
+
+  * Description: May be used to provide an XNAT password if one is not set 
+    through the configuration files. If this is set, XNAT_USER must be as well.

--- a/migrations/versions/5dc31b2f9fb4_.py
+++ b/migrations/versions/5dc31b2f9fb4_.py
@@ -17,16 +17,31 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('study_sites', sa.Column('xnat_archive', sa.String(length=32), nullable=True))
-    op.add_column('study_sites', sa.Column('xnat_convention', sa.String(length=10), nullable=True))
-    op.add_column('study_sites', sa.Column('xnat_credentials', sa.String(length=128), nullable=True))
-    op.add_column('study_sites', sa.Column('xnat_port', sa.Integer(), nullable=True))
-    op.add_column('study_sites', sa.Column('xnat_server', sa.String(length=128), nullable=True))
+    op.add_column(
+        'study_sites',
+        sa.Column('xnat_archive', sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        'study_sites',
+        sa.Column(
+            'xnat_convention',
+            sa.String(length=10),
+            nullable=True,
+            server_default='KCNI'
+        )
+    )
+    op.add_column(
+        'study_sites',
+        sa.Column('xnat_credentials', sa.String(length=128), nullable=True)
+    )
+    op.add_column(
+        'study_sites',
+        sa.Column('xnat_url', sa.String(length=128), nullable=True)
+    )
 
 
 def downgrade():
-    op.drop_column('study_sites', 'xnat_server')
-    op.drop_column('study_sites', 'xnat_port')
+    op.drop_column('study_sites', 'xnat_url')
     op.drop_column('study_sites', 'xnat_credentials')
     op.drop_column('study_sites', 'xnat_convention')
     op.drop_column('study_sites', 'xnat_archive')

--- a/migrations/versions/5dc31b2f9fb4_.py
+++ b/migrations/versions/5dc31b2f9fb4_.py
@@ -1,0 +1,32 @@
+"""Add XNAT settings columns to StudySite table.
+
+Revision ID: 5dc31b2f9fb4
+Revises: 4a842feae63a
+Create Date: 2021-12-03 18:47:00.540128
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5dc31b2f9fb4'
+down_revision = '4a842feae63a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('study_sites', sa.Column('xnat_archive', sa.String(length=32), nullable=True))
+    op.add_column('study_sites', sa.Column('xnat_convention', sa.String(length=10), nullable=True))
+    op.add_column('study_sites', sa.Column('xnat_credentials', sa.String(length=128), nullable=True))
+    op.add_column('study_sites', sa.Column('xnat_port', sa.Integer(), nullable=True))
+    op.add_column('study_sites', sa.Column('xnat_server', sa.String(length=128), nullable=True))
+
+
+def downgrade():
+    op.drop_column('study_sites', 'xnat_server')
+    op.drop_column('study_sites', 'xnat_port')
+    op.drop_column('study_sites', 'xnat_credentials')
+    op.drop_column('study_sites', 'xnat_convention')
+    op.drop_column('study_sites', 'xnat_archive')

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ uWSGI==2.0.18
 Werkzeug==0.16.0
 wrapt==1.11.2
 WTForms==2.2.1
+xnat==0.3.28


### PR DESCRIPTION
This adds:

- `dashboard.models.utils` functions to push the data to xnat (in a separate thread to avoid slowness for users)
- New settings added to `dashboard.config` for xnat
- A migration script to update the schema to hold xnat configuration information for each study / site 
- A documentation update for the new config settings.