### PR TITLE
[FIX] Address some edge cases with pushing to XNAT usability fields

### DIFF
--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -97,7 +97,7 @@ def update_xnat_usability(scan, app_config):
     site_settings = study.sites[scan.session.site.name]
 
     if not site_settings.xnat_url:
-        logger.info(f"{study} - No xnat url. QC will not be pushed to XNAT.")
+        logger.info(f"{study.id} - No xnat url. Skipping QC push to XNAT.")
         return
 
     exp_name = getattr(

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -138,6 +138,13 @@ def get_xnat_credentials(site_settings, app_config):
         password = app_config.get('XNAT_PASS')
         return user, password
 
+    if not site_settings.xnat_credentials:
+        logger.info(
+            f"No XNAT credentials provided for {site_settings.study.id}. "
+            "QC will not be pushed to XNAT database."
+        )
+        return
+
     try:
         with open(site_settings.xnat_credentials) as fh:
             contents = fh.readlines()

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -133,7 +133,7 @@ def get_xnat_credentials(site_settings, app_config):
         app_config (:obj:`dict`): Configuration of the current app instance,
             as retrieved from current_app.config
     """
-    if app_config.get('XNAT_USER'):
+    if not site_settings.xnat_credentials and app_config.get('XNAT_USER'):
         user = app_config.get('XNAT_USER')
         password = app_config.get('XNAT_PASS')
         return user, password

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -199,4 +199,5 @@ def async_xnat_update(xnat_url, user, password, xnat_archive, exp_name,
         xnat_scan = matched[0]
         xnat_scan.quality = quality
         if comment:
-            xnat_scan.note = comment
+            # XNAT max comment length is 255 chars
+            xnat_scan.note = comment[0:255]

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -96,6 +96,10 @@ def update_xnat_usability(scan, app_config):
     study = scan.get_study()
     site_settings = study.sites[scan.session.site.name]
 
+    if not site_settings.xnat_url:
+        logger.info(f"{study} - No xnat url. QC will not be pushed to XNAT.")
+        return
+
     exp_name = getattr(
         scan.session, site_settings.xnat_convention.lower() + "_name"
     )

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -6,6 +6,7 @@ import operator
 import json
 import time
 import logging
+from urllib.parse import quote, unquote
 from uuid import uuid4
 from datetime import datetime
 
@@ -200,4 +201,6 @@ def async_xnat_update(xnat_url, user, password, xnat_archive, exp_name,
         xnat_scan.quality = quality
         if comment:
             # XNAT max comment length is 255 chars
-            xnat_scan.note = comment[0:255]
+            safe_comment = comment if len(quote(comment)) < 255 \
+                    else unquote(quote(comment)[0:243]) + " [...]"
+            xnat_scan.note = safe_comment

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -198,4 +198,5 @@ def async_xnat_update(xnat_url, user, password, xnat_archive, exp_name,
 
         xnat_scan = matched[0]
         xnat_scan.quality = quality
-        xnat_scan.note = comment
+        if comment:
+            xnat_scan.note = comment

--- a/dashboard/models/utils.py
+++ b/dashboard/models/utils.py
@@ -202,5 +202,5 @@ def async_xnat_update(xnat_url, user, password, xnat_archive, exp_name,
         if comment:
             # XNAT max comment length is 255 chars
             safe_comment = comment if len(quote(comment)) < 255 \
-                    else unquote(quote(comment)[0:243]) + " [...]"
+                else unquote(quote(comment)[0:243]) + " [...]"
             xnat_scan.note = safe_comment


### PR DESCRIPTION
This PR ensures

- That a particular study or site can opt out of pushing QC to xnat by just un-setting the xnat_url in the database https://github.com/TIGRLab/datman-dashboard/commit/ad3b636a1a358c1235190523d89d91ed26ffb9a2
- That a credentials file set for a single site / study can override the environment user/password for xnat  a7e6d238c805433deaa5227e98b31cd2311966ae
- That a more descriptive message will be logged if a study/site hasnt provided a credentials file and the env user/password arent set 490f22a199bd03e39f30d95ec7a93c8af8ab6409
- That comments of 'None' wont be added to XNAT when a user comment isnt given 55d67ebb6fd2d81cef8b3885ca34cf2ea72a6a8a
- That comments that are too long for XNAT will now be truncated to fit 65eeffa16d243e507f8254bd9fd657bd34dc96e6
- That comments that change length due to character conversion also get truncated e0b6b62d1291768308321e96a16887935c493f67