### PR TITLE
[ENH] Add a config parser to update study settings from datman config files

### DIFF
--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -142,7 +142,7 @@ def update_study(study_id, config, skip_delete=False, delete_all=False):
     if ignore:
         return
 
-    study = dashboard.queries.get_studies(study_id, create=True)
+    study = dashboard.queries.get_studies(study_id, create=True)[0]
 
     # Metadata / study-wide settings here
     try:
@@ -246,7 +246,7 @@ def update_redcap(config):
 
 
 def read_token(config):
-    metadata = config.get_path('meta')
+    metadata = config.get_path("meta")
     token_file = config.get_key("RedcapToken")
     token_path = os.path.join(metadata, token_file)
     try:
@@ -274,64 +274,64 @@ def update_site(study, site_id, config, skip_delete=False, delete_all=False):
     except UndefinedSetting:
         notes = None
 
-    # try:
-    study.update_site(site_id, redcap=rc_setting, notes=notes, code=code,
-                      create=True)
-    # except Exception as e:
-    #     logger.error(f"Failed updating settings for study {study} and site "
-    #                  f"{site_id}. Reason - {e}")
+    try:
+        study.update_site(site_id, redcap=rc_setting, notes=notes, code=code,
+                          create=True)
+    except Exception as e:
+        logger.error(f"Failed updating settings for study {study} and site "
+                     f"{site_id}. Reason - {e}")
 
-    # update_expected_scans(study, site_id, config, skip_delete, delete_all)
+    update_expected_scans(study, site_id, config, skip_delete, delete_all)
 
 
-# def update_expected_scans(study, site_id, config, skip_delete=False,
-#                           delete_all=False):
-#     """Update number and type of expected scans for a site.
-#     Args:
-#         study (:obj:`dashboard.dashboard.models.Study`): A study from the
-#             database.
-#         site_id (:obj:`str`): The name of a site configured for the study.
-#         config (:obj:`datman.config.config`): A config instance for the study.
-#         skip_delete (bool, optional): Don't prompt the user and skip deletion
-#             of any scan records no longer in the config files.
-#         delete_all (bool, optional): Don't prompt the user and delete any
-#             scan records no longer in the config files.
-#     """
-#     try:
-#         tag_settings = config.get_tags(site_id)
-#     except UndefinedSetting:
-#         logger.debug(f"No tags defined for site {site_id}. Skipping update.")
-#         return
-#
-#     if site_id in study.scantypes:
-#         undefined = [entry for entry in study.scantypes[site_id]
-#                      if entry.scantype_id not in tag_settings]
-#         if undefined:
-#             delete_records(
-#                 undefined,
-#                 prompt="Expected scan type {} not defined in config files.",
-#                 skip_delete=skip_delete,
-#                 delete_all=delete_all
-#             )
-#
-#     for tag in tag_settings:
-#         try:
-#             sub = tag_settings.get(tag, 'Count')
-#         except KeyError:
-#             sub = None
-#
-#         try:
-#             pha = tag_settings.get(tag, 'PhaCount')
-#         except KeyError:
-#             pha = None
-#
-#         try:
-#             study.update_scantype(
-#                 site_id, tag, num=sub, pha_num=pha, create=True
-#             )
-#         except Exception as e:
-#             logger.error(f"Failed to update expected scans for {study.id} "
-#                          f"site {site_id} and tag {tag}. Reason - {e}.")
+def update_expected_scans(study, site_id, config, skip_delete=False,
+                          delete_all=False):
+    """Update number and type of expected scans for a site.
+    Args:
+        study (:obj:`dashboard.dashboard.models.Study`): A study from the
+            database.
+        site_id (:obj:`str`): The name of a site configured for the study.
+        config (:obj:`datman.config.config`): A config instance for the study.
+        skip_delete (bool, optional): Don't prompt the user and skip deletion
+            of any scan records no longer in the config files.
+        delete_all (bool, optional): Don't prompt the user and delete any
+            scan records no longer in the config files.
+    """
+    try:
+        tag_settings = config.get_tags(site_id)
+    except UndefinedSetting:
+        logger.debug(f"No tags defined for site {site_id}. Skipping update.")
+        return
+
+    if site_id in study.scantypes:
+        undefined = [entry for entry in study.scantypes[site_id]
+                     if entry.scantype_id not in tag_settings]
+        if undefined:
+            delete_records(
+                undefined,
+                prompt="Expected scan type {} not defined in config files.",
+                skip_delete=skip_delete,
+                delete_all=delete_all
+            )
+
+    for tag in tag_settings:
+        try:
+            sub = tag_settings.get(tag, 'Count')
+        except KeyError:
+            sub = None
+
+        try:
+            pha = tag_settings.get(tag, 'PhaCount')
+        except KeyError:
+            pha = None
+
+        try:
+            study.update_scantype(
+                site_id, tag, num=sub, pha_num=pha, create=True
+            )
+        except Exception as e:
+            logger.error(f"Failed to update expected scans for {study.id} "
+                         f"site {site_id} and tag {tag}. Reason - {e}.")
 
 
 def update_tags(config, skip_delete=False, delete_all=False):

--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -296,10 +296,8 @@ def update_site(study, site_id, config, skip_delete=False, delete_all=False):
     except UndefinedSetting:
         pass
 
-    settings["create"] = True
-
     try:
-        study.update_site(site_id, **settings)
+        study.update_site(site_id, create=True, **settings)
     except Exception as e:
         logger.error(f"Failed updating settings for study {study} and site "
                      f"{site_id}. Reason - {e}")

--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -172,9 +172,9 @@ def update_study(study_id, config, skip_delete=False, delete_all=False):
 
     study = dashboard.queries.get_studies(study_id, create=True)[0]
 
-    update_setting(study, 'description', config, 'Description')
-    update_setting(study, 'name', config, 'FullName')
-    update_setting(study, 'is_open', config, 'IsOpen')
+    update_setting(study, "description", config, "Description")
+    update_setting(study, "name", config, "FullName")
+    update_setting(study, "is_open", config, "IsOpen")
     update_redcap(config)
 
     try:
@@ -230,11 +230,11 @@ def update_redcap(config):
     except Exception:
         pass
 
-    update_setting(rc_config, 'date_field', config, 'RedcapDate')
-    update_setting(rc_config, 'comment_field', config, 'RedcapComments')
-    update_setting(rc_config, 'session_id_field', config, 'RedcapSubj')
-    update_setting(rc_config, 'completed_field', config, 'RedcapStatus')
-    update_setting(rc_config, 'completed_value', config, 'RedcapStatusValue')
+    update_setting(rc_config, "date_field", config, "RedcapDate")
+    update_setting(rc_config, "comment_field", config, "RedcapComments")
+    update_setting(rc_config, "session_id_field", config, "RedcapSubj")
+    update_setting(rc_config, "completed_field", config, "RedcapStatus")
+    update_setting(rc_config, "completed_value", config, "RedcapStatusValue")
     rc_config.save()
 
 
@@ -275,29 +275,29 @@ def update_site(study, site_id, config, skip_delete=False, delete_all=False):
     settings = collect_settings(
         config,
         {
-            'code': 'StudyTag',
-            'redcap': 'UsesRedcap',
-            'notes': 'UsesTechNotes',
-            'xnat_archive': 'XnatArchive',
-            'xnat_convention': 'XnatConvention'
+            "code": "StudyTag",
+            "redcap": "UsesRedcap",
+            "notes": "UsesTechNotes",
+            "xnat_archive": "XnatArchive",
+            "xnat_convention": "XnatConvention"
         },
         site=site_id
     )
 
     try:
-        xnat_fname = config.get_key('XnatCredentials', site=site_id)
-        settings['xnat_credentials'] = os.path.join(
-            config.get_path('meta'), xnat_fname
+        xnat_fname = config.get_key("XnatCredentials", site=site_id)
+        settings["xnat_credentials"] = os.path.join(
+            config.get_path("meta"), xnat_fname
         )
     except UndefinedSetting:
         pass
 
     try:
-        settings['xnat_url'] = get_server(config)
+        settings["xnat_url"] = get_server(config)
     except UndefinedSetting:
         pass
 
-    settings['create'] = True
+    settings["create"] = True
 
     try:
         study.update_site(site_id, **settings)
@@ -449,6 +449,7 @@ def update_setting(record, attribute, config, key, site=None):
     else:
         setattr(record, attribute, value)
 
+
 def collect_settings(config, key_map, site=None):
     all_vals = {}
     for attr_name in key_map:
@@ -458,6 +459,7 @@ def collect_settings(config, key_map, site=None):
             val = None
         all_vals[attr_name] = val
     return all_vals
+
 
 if __name__ == "__main__":
     main()

--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -13,8 +13,7 @@ for a study, like 'FMAP', will also delete all scan records for that study with
 that tag).
 
 To prevent a project's settings file from being added to the database
-add the key 'DB_IGNORE', with any value other than the boolean False, to
-the settings file.
+add 'DB_IGNORE: True' to the settings file.
 
 Usage:
     parse_config.py [options]

--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python
+"""Update the dashboard's configuration based on Datman's config yaml files.
+
+This script should be run by a user with permission to update the dashboard's
+database.
+
+Any new studies that are found will be added to the database and existing
+studies are updated to match the config files wherever the database differs.
+The user is also given the option to delete any records (tags, studies, sites)
+that aren't found in the config files. Be warned: these deletes will cascade to
+scans that reference the bad values (e.g. deleting a tag that's no longer used
+for a study, like 'FMAP', will also delete all scan records for that study with
+that tag).
+
+To prevent a project's settings file from being added to the database
+add the key 'DB_IGNORE', with any value other than the boolean False, to
+the settings file.
+
+Usage:
+    parse_config.py [options]
+    parse_config.py [options] <study>
+
+Args:
+    <study>         Only update the configuration for the given study. Note
+                    that this will cause errors if a tag is entirely new
+                    (i.e. the global configuration must define a tag before
+                    a study can reference it).
+Options:
+    --accept        Automatically answer 'y' to all prompts. Use with caution:
+                    Deletes for studies + tags will purge associated
+                    scan / timepoint / session records and updates may
+                    overwrite newer information in the database if the
+                    configuration files are out of date.
+    --decline       Automatically answer 'n' to all prompts. Records found in
+                    the database that don't match configuration files will
+                    be left as is and when there's a conflict between certain
+                    values (like the contents of the readme) no changes will
+                    be made.
+    --quiet, -q     Only report errors.
+    --verbose, -v   Be chatty.
+    --debug, -d     Be extra chatty.
+"""
+import os
+import logging
+
+from docopt import docopt
+
+import datman.config
+from datman.exceptions import UndefinedSetting
+import dashboard
+
+dashboard.connect_db()
+
+logging.basicConfig(level=logging.WARN,
+                    format="[%(name)s] %(levelname)s: %(message)s")
+logger = logging.getLogger(os.path.basename(__file__))
+
+
+def main():
+    args = docopt(__doc__)
+    study = args['<study>']
+    accept_all = args['--accept']
+    skip_all = args['--decline']
+    quiet = args['--quiet']
+    verbose = args['--verbose']
+    debug = args['--debug']
+
+    if verbose:
+        logger.setLevel(logging.INFO)
+    if debug:
+        logger.setLevel(logging.DEBUG)
+    if quiet:
+        logger.setLevel(logging.ERROR)
+
+    config = datman.config.config()
+
+    if study:
+        update_study(study, config)
+        return
+
+    update_tags(config, skip_all, accept_all)
+    update_studies(config, skip_all, accept_all)
+
+
+def delete_records(records, prompt=None, delete_func=None, skip_delete=False,
+                   delete_all=False):
+    logger.debug(f"Found {len(records)} records not defined in config files.")
+
+    if skip_delete:
+        logger.debug("Skipping deletion.")
+        return
+
+    if not prompt:
+        prompt = ("Record {} not specified by config files. If removed any "
+                  "records associated with it will also be deleted.")
+
+    if not delete_func:
+        def delete_func(x):
+            x.delete()
+
+    for record in records:
+        if delete_all:
+            remove = True
+        else:
+            remove = prompt_delete(prompt.format(record))
+
+        if not remove:
+            logger.info(f"Skipping deletiong of {record}")
+            continue
+
+        logger.info(f"Removing {record}")
+
+        try:
+            delete_func(record)
+        except Exception as e:
+            logger.error(f"Failed deleting {record}. Reason - {e}")
+
+
+def prompt_user(message):
+    answer = input(message).strip().lower()
+    if answer not in ['y', 'n', '']:
+        raise RuntimeError(f"Invalid user input {answer}")
+    return answer == 'y'
+
+
+def prompt_delete(message):
+    return prompt_user(message + " Delete? (y/[n]) ")
+
+
+def update_study(study_id, config, skip_delete=False, delete_all=False):
+    try:
+        config.set_study(study_id)
+    except Exception as e:
+        logger.error(f"Can't access config for {study_id}. Reason - {e}")
+        return
+
+    try:
+        ignore = config.get_key('DbIgnore')
+    except UndefinedSetting:
+        ignore = False
+
+    if ignore:
+        return
+
+    study = dashboard.queries.get_studies(study_id, create=True)
+
+    # Metadata / study-wide settings here
+    try:
+        descr = config.get_key('Description')
+    except UndefinedSetting:
+        pass
+    else:
+        study.description = descr
+
+    try:
+        full_name = config.get_key('FullName')
+    except UndefinedSetting:
+        pass
+    else:
+        study.name = full_name
+
+    try:
+        is_open = config.get_key('IsOpen')
+    except UndefinedSetting:
+        pass
+    else:
+        study.is_open = is_open
+
+    update_redcap(config)
+
+    try:
+        sites = config.get_sites()
+    except UndefinedSetting:
+        logger.error(f"No sites defined for {study_id}")
+        return
+
+    undefined = [site_id for site_id in study.sites if site_id not in sites]
+    delete_records(
+        undefined,
+        prompt=("Site {} will be deleted from study "
+                f"{study.id}. Any records referencing this study/site pair "
+                "will be removed."),
+        delete_func=lambda x: study.delete_site(x),
+        skip_delete=skip_delete,
+        delete_all=delete_all
+    )
+
+    for site_id in sites:
+        update_site(
+            study,
+            site_id,
+            config,
+            skip_delete=skip_delete,
+            delete_all=delete_all
+        )
+
+
+def update_redcap(config):
+    try:
+        project = config.get_key("RedcapProjectId")
+        instrument = config.get_key("RedcapInstrument")
+        url = config.get_key("RedcapUrl")
+    except UndefinedSetting:
+        return
+
+    rc_config = dashboard.queries.get_redcap_config(
+        project, instrument, url, create=True
+    )
+
+    if not rc_config:
+        logger.error(f"Failed getting config for {project} {instrument} {url}")
+        return
+
+    try:
+        rc_config.token = read_token(config)
+    except Exception:
+        pass
+
+    try:
+        rc_config.date_field = config.get_key("RedcapDate")
+    except UndefinedSetting:
+        pass
+
+    try:
+        rc_config.comment_field = config.get_key("RedcapComments")
+    except UndefinedSetting:
+        pass
+
+    try:
+        rc_config.session_id_field = config.get_key("RedcapSubj")
+    except UndefinedSetting:
+        pass
+
+    try:
+        rc_config.completed_field = config.get_key("RedcapStatus")
+    except UndefinedSetting:
+        pass
+
+    try:
+        # this could be an issue due to lists...
+        rc_config.completed_value = config.get_key("RedcapStatusValue")
+    except UndefinedSetting:
+        pass
+
+    rc_config.save()
+
+
+def read_token(config):
+    metadata = config.get_path('meta')
+    token_file = config.get_key("RedcapToken")
+    token_path = os.path.join(metadata, token_file)
+    try:
+        with open(token_path, "r") as fh:
+            return fh.readline().strip()
+    except Exception as e:
+        logger.error(
+            f"Failed to read RedCap token at {token_path}. Reason - {e}"
+        )
+
+
+def update_site(study, site_id, config, skip_delete=False, delete_all=False):
+    try:
+        code = config.get_key('StudyTag', site=site_id)
+    except UndefinedSetting:
+        code = None
+
+    try:
+        rc_setting = config.get_key('UsesRedcap', site=site_id)
+    except UndefinedSetting:
+        rc_setting = None
+
+    try:
+        notes = config.get_key('UsesTechNotes', site=site_id)
+    except UndefinedSetting:
+        notes = None
+
+    # try:
+    study.update_site(site_id, redcap=rc_setting, notes=notes, code=code,
+                      create=True)
+    # except Exception as e:
+    #     logger.error(f"Failed updating settings for study {study} and site "
+    #                  f"{site_id}. Reason - {e}")
+
+    # update_expected_scans(study, site_id, config, skip_delete, delete_all)
+
+
+# def update_expected_scans(study, site_id, config, skip_delete=False,
+#                           delete_all=False):
+#     """Update number and type of expected scans for a site.
+#     Args:
+#         study (:obj:`dashboard.dashboard.models.Study`): A study from the
+#             database.
+#         site_id (:obj:`str`): The name of a site configured for the study.
+#         config (:obj:`datman.config.config`): A config instance for the study.
+#         skip_delete (bool, optional): Don't prompt the user and skip deletion
+#             of any scan records no longer in the config files.
+#         delete_all (bool, optional): Don't prompt the user and delete any
+#             scan records no longer in the config files.
+#     """
+#     try:
+#         tag_settings = config.get_tags(site_id)
+#     except UndefinedSetting:
+#         logger.debug(f"No tags defined for site {site_id}. Skipping update.")
+#         return
+#
+#     if site_id in study.scantypes:
+#         undefined = [entry for entry in study.scantypes[site_id]
+#                      if entry.scantype_id not in tag_settings]
+#         if undefined:
+#             delete_records(
+#                 undefined,
+#                 prompt="Expected scan type {} not defined in config files.",
+#                 skip_delete=skip_delete,
+#                 delete_all=delete_all
+#             )
+#
+#     for tag in tag_settings:
+#         try:
+#             sub = tag_settings.get(tag, 'Count')
+#         except KeyError:
+#             sub = None
+#
+#         try:
+#             pha = tag_settings.get(tag, 'PhaCount')
+#         except KeyError:
+#             pha = None
+#
+#         try:
+#             study.update_scantype(
+#                 site_id, tag, num=sub, pha_num=pha, create=True
+#             )
+#         except Exception as e:
+#             logger.error(f"Failed to update expected scans for {study.id} "
+#                          f"site {site_id} and tag {tag}. Reason - {e}.")
+
+
+def update_tags(config, skip_delete=False, delete_all=False):
+    try:
+        tag_settings = config.get_key('ExportSettings')
+    except UndefinedSetting:
+        logger.info('No defined tags found, skipping tag update.')
+        return
+
+    for tag in tag_settings:
+        db_entry = dashboard.queries.get_scantypes(tag, create=True)[0]
+
+        try:
+            qc_type = tag_settings[tag]['QcType']
+        except KeyError:
+            qc_type = None
+        try:
+            pha_type = tag_settings[tag]['QcPha']
+        except KeyError:
+            pha_type = None
+
+        db_entry.qc_type = qc_type
+        db_entry.pha_type = pha_type
+        db_entry.save()
+
+    all_tags = dashboard.queries.get_scantypes()
+    undefined = [record for record in all_tags
+                 if record.tag not in tag_settings]
+
+    if not undefined:
+        return
+
+    delete_records(
+        undefined,
+        prompt=("Tag {} undefined. If deleted any scan records with this "
+                "tag will also be removed."),
+        skip_delete=skip_delete,
+        delete_all=delete_all
+    )
+
+
+def update_studies(config, skip_delete=False, delete_all=False):
+    try:
+        studies = config.get_key('Projects').keys()
+    except UndefinedSetting:
+        logger.debug('No configured projects detected.')
+        return
+
+    all_studies = dashboard.queries.get_studies()
+
+    undefined = [study for study in all_studies
+                 if study.id not in studies]
+
+    if undefined:
+        delete_records(
+            undefined,
+            prompt=("Study {} missing from config files. If deleted any "
+                    "timepoints and their contents will also be deleted."),
+            skip_delete=skip_delete,
+            delete_all=delete_all
+        )
+
+    for study in studies:
+        update_study(study, config, skip_delete, delete_all)
+
+
+if __name__ == "__main__":
+    main()

--- a/config/database.py
+++ b/config/database.py
@@ -21,6 +21,15 @@ SQLALCHEMY_DATABASE_URI = 'postgresql://{user}:{pwd}@{srvr}/{db}'.format(
     srvr=server,
     db=db_name)
 
+# Configure the test database to use for unit tests
+test_db_name = os.environ.get('POSTGRES_TEST_DATABASE') or 'test_dashboard'
+
+SQLALCHEMY_TEST_DATABASE_URI = 'postgresql://{user}:{pwd}@{srvr}/{db}'.format(
+    user=user,
+    pwd=password,
+    srvr=server,
+    db=test_db_name)
+
 # Timezone offset used for timezone aware timestamps. Default is Eastern time
 # Used by psycopg2.tz.FixedOffsetTimezone in the models
 TZ_OFFSET = os.environ.get('TIMEZONE') or -240

--- a/containers/devel/dashboard.env
+++ b/containers/devel/dashboard.env
@@ -22,6 +22,7 @@ POSTGRES_PASS=devdatabasepassword
 POSTGRES_SRVR=devel_postgres
 POSTGRES_USER=dashboard
 POSTGRES_DATABASE=dashboard
+# POSTGRES_TEST_DATABASE=test_dashboard
 
 
 # TIMEZONE=-240

--- a/containers/prod/dashboard.env
+++ b/containers/prod/dashboard.env
@@ -22,6 +22,7 @@ POSTGRES_PASS=
 POSTGRES_SRVR=dash_postgres
 POSTGRES_USER=dashboard
 POSTGRES_DATABASE=dashboard
+# POSTGRES_TEST_DATABASE=test_dashboard
 
 
 # TIMEZONE=-240

--- a/dashboard/blueprints/main/views.py
+++ b/dashboard/blueprints/main/views.py
@@ -147,7 +147,6 @@ def study(study_id=None, active_tab=None):
     form.study_id.data = study_id
 
     return render_template('study.html',
-                           metricnames=study.get_valid_metric_names(),
                            study=study,
                            form=form,
                            active_tab=active_tab,

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -9,7 +9,7 @@ import redcap as REDCAP
 
 from .monitors import monitor_scan_import, monitor_scan_download
 from dashboard.models import Session, Timepoint, RedcapRecord, RedcapConfig
-from dashboard.queries import get_study
+from dashboard.queries import get_studies
 from dashboard.exceptions import RedcapException
 import datman.scanid
 
@@ -149,7 +149,7 @@ def set_session(name):
 
 
 def find_study(ident):
-    study = get_study(tag=ident.study, site=ident.site)
+    study = get_studies(tag=ident.study, site=ident.site)
     if not study:
         raise RedcapException("Invalid study/site combination: {} {}"
                               "".format(ident.study, ident.site))

--- a/dashboard/blueprints/users/views.py
+++ b/dashboard/blueprints/users/views.py
@@ -96,7 +96,7 @@ def user(user_id=None):
         if removed_studies:
             updated_user.remove_studies(removed_studies)
 
-        updated_user.save_changes()
+        updated_user.save()
 
         flash("User profile updated.")
         return redirect(url_for('users.user', user_id=submitted_id))

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -669,7 +669,8 @@ class Study(TableMixin, db.Model):
             db.session.rollback()
             raise InvalidDataException(
                 "Failed to update site {} for study {}. Reason - {}".format(
-                site_id, self.id, e)
+                    site_id, self.id, e
+                )
             )
 
     def update_scantype(self, site_id, scantype, num=None, pha_num=None,

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -592,7 +592,8 @@ class Study(TableMixin, db.Model):
             site.delete()
 
     def update_site(self, site_id, redcap=None, notes=None, code=None,
-                    create=False):
+                    xnat_archive=None, xnat_convention="KCNI",
+                    xnat_credentials=None, xnat_url=None, create=False):
         """Update a site configured for this study (or configure a new one).
 
         Args:
@@ -606,6 +607,16 @@ class Study(TableMixin, db.Model):
             code (str, optional): The study code used for IDs for this study
                 and site combination. Updates only if value provided.
                 Defaults to None.
+            xnat_archive (str, optional): The name of the archive on XNAT
+                where data for this site is stored. Updates only if value
+                provided. Defaults to None.
+            xnat_convention (str, optional): The naming convention used
+                on the XNAT server for this site. Defaults to 'KCNI'.
+            xnat_credentials (str, optional): The full path to the credentials
+                file to read when accessing this site's XNAT archive.
+                Defaults to None.
+            xnat_url (str, optional): The URL to use when accessing this
+                site's XNAT archive. Defaults to None.
             create (bool, optional): Whether to create the site and add it
                 to this study if it isnt already associated. Defaults to False.
 
@@ -639,6 +650,17 @@ class Study(TableMixin, db.Model):
 
         if code is not None:
             study_site.code = code
+
+        if xnat_archive is not None:
+            study_site.xnat_archive = xnat_archive
+
+        study_site.xnat_convention = xnat_convention
+
+        if xnat_credentials is not None:
+            study_site.xnat_credentials = xnat_credentials
+
+        if xnat_url is not None:
+            study_site.xnat_url = xnat_url
 
         db.session.add(study_site)
         try:

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1195,15 +1195,15 @@ class Timepoint(TableMixin, db.Model):
         db.session.add(empty_session)
         db.session.commit()
 
-    # def delete(self):
-    #     """
-    #     This will cascade and also delete any records that reference
-    #     the current timepoint, so be careful :)
-    #     """
-    #     for num in self.sessions:
-    #         self.sessions[num].delete()
-    #     db.session.delete(self)
-    #     db.session.commit()
+    def delete(self):
+        """
+        This will cascade and also delete any records that reference
+        the current timepoint, so be careful :)
+        """
+        for num in self.sessions:
+            self.sessions[num].delete()
+        db.session.delete(self)
+        db.session.commit()
 
     def report_incidental_finding(self, user_id, comment):
         new_finding = IncidentalFinding(user_id, self.name, comment)
@@ -1453,20 +1453,20 @@ class Session(TableMixin, db.Model):
             entries.append(scan.get_checklist_entry())
         return entries
 
-    # def delete(self):
-    #     """
-    #     This will also delete anything referencing the current session (i.e.
-    #     any scans, redcap comments, blacklist entries or dismissed 'missing
-    #     scans' errors)
-    #     """
-    #     if (self.redcap_record and
-    #             self.redcap_record.record and
-    #             not self.redcap_record.record.is_shared):
-    #         # Without this, deletes wont propagate correctly to RedcapRecord
-    #         # and you end up with orphaned records
-    #         db.session.delete(self.redcap_record.record)
-    #     db.session.delete(self)
-    #     db.session.commit()
+    def delete(self):
+        """
+        This will also delete anything referencing the current session (i.e.
+        any scans, redcap comments, blacklist entries or dismissed 'missing
+        scans' errors)
+        """
+        if (self.redcap_record and
+                self.redcap_record.record and
+                not self.redcap_record.record.is_shared):
+            # Without this, deletes wont propagate correctly to RedcapRecord
+            # and you end up with orphaned records
+            db.session.delete(self.redcap_record.record)
+        db.session.delete(self)
+        db.session.commit()
 
     def add_task(self, file_path, name=None):
         for item in self.task_files:

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -482,12 +482,6 @@ class Study(TableMixin, db.Model):
         lazy='dynamic',
         cascade="all, delete",
     )
-    standards = db.relationship(
-        'GoldStandard',
-        secondary='expected_scans',
-        collection_class=lambda: utils.DictListCollection('site'),
-        viewonly=True,
-    )
 
     def __init__(self,
                  study_id,

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -2,46 +2,72 @@
 """
 import logging
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, or_, func
 
 from dashboard import db
 from .models import (Timepoint, Session, Scan, Study, Site, Metrictype,
                      MetricValue, Scantype, StudySite, AltStudyCode, User,
-                     study_timepoints_table)
+                     study_timepoints_table, RedcapConfig)
 import datman.scanid as scanid
 
 logger = logging.getLogger(__name__)
 
 
-def get_study(name=None, tag=None, site=None):
-    """Retrieve a study from the database.
+def get_studies(name=None, tag=None, site=None, create=False):
+    """Find a study or studies based on search terms.
 
-    Requires enough information to uniquely identify a match in the database,
-    if one exists. This means either a 'name' or a 'tag' / 'site' pair.
+    If no terms are provided all studies in the database will be returned.
 
     Args:
-        name (str, optional): A short-form study name (e.g. 'SPINS'). Defaults
-            to None.
-        tag (str, optional): The session study ID tag (i.e. the code used for
-            the first field of datman style IDs). This may be the same as
-            'name' in some cases. Defaults to None.
-        site (str, optional): A session site ID tag (i.e. the code used to
-            identify scan site). Defaults to None.
+        name (str, optional): The name of a specific study. If given other
+            search terms will be ignored. Defaults to None.
+        tag (str, optional): A study tag / code (e.g. SPN01) as found in the
+            first part of datman style subject IDs. Defaults to None.
+        site (str, optional): A site tag (e.g. CMH) as found in the second
+            part of datman style subject IDs. Defaults to None.
+        create (bool, optional): Whether to create the study if it doesnt
+            exist. This option is ignored if 'name' isn't provided.
+            Defaults to False.
 
     Returns:
-        :obj:`list`: a list of :obj:`dashboard.models.Study` objects that match
-            the given values or the empty list.
+        list: A list of matching :obj:`dashboard.models.Study` records. May
+            be empty if no matches found.
     """
+    query = Study.query
+
+    if not (name or tag or site):
+        return query.all()
+
     if name:
-        return Study.query.filter(Study.id == name).all()
-    studies = StudySite.query.filter(StudySite.code == tag)
+        found = query.filter(Study.id == name).all()
+        if create and not found:
+            study = Study(name)
+            try:
+                db.session.add(study)
+                db.session.commit()
+            except Exception as e:
+                db.session.rollback()
+                raise e
+            found = [study]
+        return found
+
+    query = query.filter(Study.id == StudySite.study_id)
+
+    if tag:
+        query = query.filter(
+            or_(StudySite.code == tag,
+                and_(Study.id == AltStudyCode.study_id,
+                     StudySite.site_id == AltStudyCode.site_id,
+                     AltStudyCode.code == tag))
+        )
+
     if site:
-        studies = studies.filter(StudySite.site_id == site)
-    if not studies.all():
-        studies = AltStudyCode.query.filter(AltStudyCode.code == tag)
-        if site:
-            studies = studies.filter(AltStudyCode.site_id == site)
-    return studies.all()
+        query = query.filter(
+            and_(Study.id == StudySite.study_id,
+                 StudySite.site_id == site)
+        )
+
+    return query.all()
 
 
 def find_subjects(search_str):
@@ -97,7 +123,7 @@ def get_study_timepoints(study, site=None, phantoms=False):
     """
 
     try:
-        study = get_study(study)[0]
+        study = get_studies(study)[0]
     except IndexError:
         logger.error('Study {} does not exist!'.format(study))
         return None
@@ -215,6 +241,39 @@ def get_user(username):
     query = User.query.filter(
         func.lower(User._username).contains(func.lower(username)))
     return query.all()
+
+
+def get_scantypes(tag_id=None, create=False):
+    """Get all tags (or one specific tag) defined in the database.
+
+    Args:
+        tag_id (str, optional): A single tag to look up. Defaults to None.
+        create (bool, optional): Whether to create a new record if tag_id
+            doesnt exist. Defaults to False.
+
+    Returns:
+        :obj:`list`: A list of Scantype records.
+    """
+    if not tag_id:
+        return Scantype.query.all()
+
+    found = Scantype.query.get(tag_id)
+    if found:
+        return [found]
+
+    if not create:
+        return []
+
+    new_tag = Scantype(tag_id)
+
+    try:
+        db.session.add(new_tag)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        raise e
+
+    return [new_tag]
 
 
 def query_metric_values_byid(**kwargs):

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -276,6 +276,17 @@ def get_scantypes(tag_id=None, create=False):
     return [new_tag]
 
 
+def get_redcap_config(project, instrument, url, create=False):
+    try:
+        project = int(project)
+    except ValueError:
+        raise InvalidDataException("Project must be an integer.")
+
+    return RedcapConfig.get_config(
+        project=project, instrument=instrument, url=url, create=create
+    )
+
+
 def query_metric_values_byid(**kwargs):
     """Queries the database for metrics matching the specifications.
         Arguments are lists of strings containing identifying names

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -8,6 +8,7 @@ from dashboard import db
 from .models import (Timepoint, Session, Scan, Study, Site, Metrictype,
                      MetricValue, Scantype, StudySite, AltStudyCode, User,
                      study_timepoints_table, RedcapConfig)
+from dashboard.exceptions import InvalidDataException
 import datman.scanid as scanid
 
 logger = logging.getLogger(__name__)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -65,6 +65,10 @@ Optional
   
   * Description: The name of the database to connect to.
   * Default value: ``dashboard``
+* **POSTGRES_TEST_DATABASE**
+
+  * Description: The name of the database to create / delete when running tests.
+  * Default value: ``test_dashboard``
 * **POSTGRES_SRVR**
 
   * Description: The postgres server to connect to. May be a fully qualified 

--- a/migrations/versions/77bce5fefcf4_.py
+++ b/migrations/versions/77bce5fefcf4_.py
@@ -1,0 +1,51 @@
+"""Add a few more columns to hold Datman config settings.
+
+Revision ID: 77bce5fefcf4
+Revises: 5dc31b2f9fb4
+Create Date: 2021-12-10 19:25:50.213883
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '77bce5fefcf4'
+down_revision = '5dc31b2f9fb4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'scantypes',
+        sa.Column('qc_type', sa.String(length=64), nullable=True)
+    )
+    op.add_column(
+        'scantypes',
+        sa.Column('pha_type', sa.String(length=64), nullable=True)
+    )
+    op.alter_column(
+        'studies',
+        'is_open',
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+        existing_server_default=sa.text('true')
+    )
+    op.add_column(
+        'study_sites',
+        sa.Column('uses_tech_notes', sa.Boolean(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('study_sites', 'uses_tech_notes')
+    op.alter_column(
+        'studies',
+        'is_open',
+        existing_type=sa.BOOLEAN(),
+        nullable=True,
+        existing_server_default=sa.text('true')
+    )
+    op.drop_column('scantypes', 'pha_type')
+    op.drop_column('scantypes', 'qc_type')

--- a/migrations/versions/77bce5fefcf4_.py
+++ b/migrations/versions/77bce5fefcf4_.py
@@ -56,7 +56,8 @@ def upgrade():
             ['site'], ['sites.name'], name='expected_scans_site_fkey'
         ),
         sa.ForeignKeyConstraint(
-            ['scantype'], ['scantypes.tag'], name='expected_scans_scantype_fkey'
+            ['scantype'], ['scantypes.tag'],
+            name='expected_scans_scantype_fkey'
         ),
         sa.ForeignKeyConstraint(
             ['study', 'site'],
@@ -88,7 +89,8 @@ def upgrade():
         ['study', 'site', 'scantype'],
     )
     op.drop_constraint(
-        'gold_standards_study_scantype_fkey', 'gold_standards', type_='foreignkey'
+        'gold_standards_study_scantype_fkey', 'gold_standards',
+        type_='foreignkey'
     )
     op.drop_table('study_scantypes')
 

--- a/migrations/versions/77bce5fefcf4_.py
+++ b/migrations/versions/77bce5fefcf4_.py
@@ -1,4 +1,4 @@
-"""Add a few more columns to hold Datman config settings.
+"""Add more Datman config settings to the database.
 
 Revision ID: 77bce5fefcf4
 Revises: 5dc31b2f9fb4
@@ -37,6 +37,64 @@ def upgrade():
         sa.Column('uses_tech_notes', sa.Boolean(), nullable=True)
     )
 
+    # Reorganize existing data into 'ExpectedScans' table
+    expected_scans = op.create_table(
+        'expected_scans',
+        sa.Column('study', sa.String(length=32), nullable=False),
+        sa.Column('site', sa.String(length=32), nullable=False),
+        sa.Column('scantype', sa.String(length=64), nullable=False),
+        sa.Column(
+            'num_expected', sa.Integer(), nullable=True, server_default='0'
+        ),
+        sa.Column(
+            'pha_num_expected', sa.Integer(), nullable=True, server_default='0'
+        ),
+        sa.ForeignKeyConstraint(
+            ['study'], ['studies.id'], name='expected_scans_study_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['site'], ['sites.name'], name='expected_scans_site_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['scantype'], ['scantypes.tag'], name='expected_scans_scantype_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['study', 'site'],
+            ['study_sites.study', 'study_sites.site'],
+            name='expected_scans_allowed_sites_fkey'
+        ),
+        sa.PrimaryKeyConstraint('study', 'site', 'scantype')
+    )
+
+    conn = op.get_bind()
+    records = conn.execute(
+        'select study_sites.study, study_sites.site, study_scantypes.scantype '
+        '  from study_sites, study_scantypes '
+        '  where study_sites.study = study_scantypes.study;'
+    )
+    op.bulk_insert(
+        expected_scans,
+        [{'study': record[0],
+          'site': record[1],
+          'scantype': record[2]}
+         for record in records]
+    )
+
+    op.create_foreign_key(
+        'gold_standards_expected_scans_fkey',
+        'gold_standards',
+        'expected_scans',
+        ['study', 'site', 'scantype'],
+        ['study', 'site', 'scantype'],
+    )
+    op.drop_constraint(
+        'gold_standards_study_fkey', 'gold_standards', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'gold_standards_study_fkey1', 'gold_standards', type_='foreignkey'
+    )
+    op.drop_table('study_scantypes')
+
 
 def downgrade():
     op.drop_column('study_sites', 'uses_tech_notes')
@@ -49,3 +107,55 @@ def downgrade():
     )
     op.drop_column('scantypes', 'pha_type')
     op.drop_column('scantypes', 'qc_type')
+
+    study_scantypes = op.create_table(
+        'study_scantypes',
+        sa.Column('study', sa.String(length=32), nullable=False),
+        sa.Column('scantype', sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['scantype'],
+            ['scantypes.tag'],
+            name='study_scantypes_scantype_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['study'],
+            ['studies.id'],
+            name='study_scantypes_study_fkey'
+        ),
+        sa.PrimaryKeyConstraint('study', 'scantype')
+    )
+
+    conn = op.get_bind()
+    records = conn.execute(
+        'select study, scantype'
+        '  from expected_scans '
+        '  group by study, scantype '
+        '  order by study, scantype;'
+    )
+    op.bulk_insert(
+        study_scantypes,
+        [{'study': record[0],
+          'scantype': record[1]}
+         for record in records]
+    )
+
+    op.drop_constraint(
+        'gold_standards_expected_scans_fkey',
+        'gold_standards',
+        type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'gold_standards_study_fkey1',
+        'gold_standards',
+        'study_sites',
+        ['study', 'site'],
+        ['study', 'site']
+    )
+    op.create_foreign_key(
+        'gold_standards_study_fkey',
+        'gold_standards',
+        'study_scantypes',
+        ['study', 'scantype'],
+        ['study', 'scantype']
+    )
+    op.drop_table('expected_scans')

--- a/migrations/versions/77bce5fefcf4_.py
+++ b/migrations/versions/77bce5fefcf4_.py
@@ -88,10 +88,7 @@ def upgrade():
         ['study', 'site', 'scantype'],
     )
     op.drop_constraint(
-        'gold_standards_study_fkey', 'gold_standards', type_='foreignkey'
-    )
-    op.drop_constraint(
-        'gold_standards_study_fkey1', 'gold_standards', type_='foreignkey'
+        'gold_standards_study_scantype_fkey', 'gold_standards', type_='foreignkey'
     )
     op.drop_table('study_scantypes')
 
@@ -145,14 +142,7 @@ def downgrade():
         type_='foreignkey'
     )
     op.create_foreign_key(
-        'gold_standards_study_fkey1',
-        'gold_standards',
-        'study_sites',
-        ['study', 'site'],
-        ['study', 'site']
-    )
-    op.create_foreign_key(
-        'gold_standards_study_fkey',
+        'gold_standards_study_scantype_fkey',
         'gold_standards',
         'study_scantypes',
         ['study', 'scantype'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Creates fixtures to ensure all tests run against a test database.
+
+This creates a test database at the start of the test session and wipes it
+clean after every test. The user you connect to postgres with must have
+permissions to create a new database.
+"""
+
+import pytest
+from sqlalchemy_utils import database_exists, create_database, drop_database
+
+import dashboard
+
+@pytest.fixture(scope="session")
+def dash_app(request):
+    app = dashboard.create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = app.config[
+        'SQLALCHEMY_TEST_DATABASE_URI'
+    ]
+
+    if not database_exists(app.config['SQLALCHEMY_DATABASE_URI']):
+        create_database(app.config['SQLALCHEMY_DATABASE_URI'])
+
+    yield app
+    drop_database(app.config['SQLALCHEMY_DATABASE_URI'])
+
+@pytest.fixture(scope="function")
+def dash_db(dash_app):
+    with dash_app.app_context():
+        dashboard.models.db.create_all()
+        yield dashboard.models.db
+        # If you remove this line the session will remain open and
+        # the tables wont be able to drop, causing the tests to freeze
+        dashboard.models.db.session.remove()
+        dashboard.models.db.drop_all()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy_utils import database_exists, create_database, drop_database
 
 import dashboard
 
+
 @pytest.fixture(scope="session")
 def dash_app(request):
     app = dashboard.create_app()
@@ -23,6 +24,7 @@ def dash_app(request):
 
     yield app
     drop_database(app.config['SQLALCHEMY_DATABASE_URI'])
+
 
 @pytest.fixture(scope="function")
 def dash_db(dash_app):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,16 +14,16 @@ import dashboard
 @pytest.fixture(scope="session")
 def dash_app(request):
     app = dashboard.create_app()
-    app.config['TESTING'] = True
-    app.config['SQLALCHEMY_DATABASE_URI'] = app.config[
-        'SQLALCHEMY_TEST_DATABASE_URI'
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = app.config[
+        "SQLALCHEMY_TEST_DATABASE_URI"
     ]
 
-    if not database_exists(app.config['SQLALCHEMY_DATABASE_URI']):
-        create_database(app.config['SQLALCHEMY_DATABASE_URI'])
+    if not database_exists(app.config["SQLALCHEMY_DATABASE_URI"]):
+        create_database(app.config["SQLALCHEMY_DATABASE_URI"])
 
     yield app
-    drop_database(app.config['SQLALCHEMY_DATABASE_URI'])
+    drop_database(app.config["SQLALCHEMY_DATABASE_URI"])
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -1,0 +1,399 @@
+import importlib
+
+import pytest
+from mock import patch, Mock, call
+
+import datman.config
+
+pc = importlib.import_module('bin.parse_config')
+
+
+class TestPromptUser:
+
+    @patch('builtins.input')
+    def test_true_only_when_y_given(self, mock_input):
+        user_input = [
+            '         ',
+            '',
+            'y',
+            'n',
+        ]
+
+        mock_input.side_effect = lambda x: user_input.pop()
+
+        assert pc.prompt_user('Test message') is False
+        assert pc.prompt_user('Test message') is True
+        assert pc.prompt_user('Test message') is False
+        assert pc.prompt_user('Test message') is False
+
+    @patch('builtins.input')
+    def test_raises_runtime_error_for_unexpected_response(self, mock_input):
+        mock_input.return_value = 'dfgsxcvqa'
+        with pytest.raises(RuntimeError):
+            pc.prompt_user('Test message')
+
+
+class TestUpdateTags:
+
+    @patch('dashboard.queries.get_scantypes')
+    def test_tag_created_in_database_if_doesnt_exist(self, mock_db_tags):
+        config = self.get_config()
+        pc.update_tags(config)
+        assert call('T1', create=True) in mock_db_tags.call_args_list
+
+    @patch('dashboard.queries.get_scantypes')
+    def test_existing_tag_updated_when_settings_changed(self, mock_db_tags):
+        config = self.get_config()
+
+        db_tag = Mock()
+        db_tag.tag = 'T1'
+        db_tag.qc_type = 'func'
+        db_tag.pha_type = 'func'
+        existing_tags = [db_tag]
+
+        mock_db_tags.side_effect = self.get_scantype_func(existing_tags)
+
+        pc.update_tags(config)
+
+        assert len(existing_tags) == 1
+        db_tag = existing_tags[0]
+        assert db_tag.tag == 'T1'
+        assert db_tag.qc_type == 'anat'
+        assert db_tag.pha_type is None
+
+    @patch('bin.parse_config.delete_records')
+    @patch('dashboard.queries.get_scantypes')
+    def test_calls_delete_records_if_undefined_tags_exist(
+            self, mock_db_tags, mock_delete):
+        config = self.get_config()
+
+        bad_tag = Mock()
+        bad_tag.tag = 'T2'
+        expected_tag = Mock()
+        expected_tag.tag = 'T1'
+        existing_tags = [bad_tag, expected_tag]
+
+        mock_db_tags.side_effect = self.get_scantype_func(existing_tags)
+
+        pc.update_tags(config)
+
+        assert mock_delete.call_count == 1
+        assert mock_delete.call_args[0] == ([bad_tag],)
+
+    def get_config(self):
+        def get_key(name):
+            if name == 'ExportSettings':
+                return {
+                            'T1': {
+                                'Formats': ['nii', 'dcm', 'mnc'],
+                                'QcType': 'anat'
+                            },
+                        }
+            raise datman.config.UndefinedSetting
+
+        config = Mock(spec=datman.config.config)
+        config.get_key = get_key
+
+        return config
+
+    def get_scantype_func(self, existing_tags):
+        # Provide a mock dashboard.queries.get_scantypes interface
+        # with 'existing_tags' as the fake records.
+        def get_scantype(tag=None, create=False):
+            if not tag:
+                return existing_tags
+
+            found = [item for item in existing_tags if item.tag == tag]
+            if not found and create:
+                new_tag = Mock()
+                new_tag.tag = tag
+                existing_tags.append(new_tag)
+                return [new_tag]
+
+            return found
+        return get_scantype
+
+
+class TestDeleteRecords:
+
+    def test_nothing_deleted_when_skip_delete_flag_set(self):
+        records = self.get_mock_records()
+        pc.delete_records(records, skip_delete=True)
+        for item in records:
+            assert item.delete.call_count == 0
+
+    def test_all_given_records_deleted_when_delete_all_set(self):
+        records = self.get_mock_records()
+        pc.delete_records(records, delete_all=True)
+        for item in records:
+            assert item.delete.call_count == 1
+
+    @patch('builtins.input')
+    def test_delete_func_used_to_delete_when_provided(self, mock_input):
+        mock_input.return_value = 'y'
+        def delete_func(x):
+            x.alt_delete()
+        records = self.get_mock_records()
+        pc.delete_records(records, delete_func=delete_func)
+
+        for item in records:
+            assert item.delete.call_count == 0
+
+        for item in records:
+            assert item.alt_delete.call_count == 1
+
+    @patch('builtins.input')
+    @patch('bin.parse_config.prompt_user')
+    def test_prompt_changed_when_flag_set(self, mock_prompt, mock_input):
+        mock_input.return_value = 'y'
+        records = self.get_mock_records()
+
+        message = 'Testing prompt flag'
+        pc.delete_records(records, prompt=message)
+        for call in mock_prompt.call_args_list:
+            assert message in call.args[0]
+
+    @patch('builtins.input')
+    def test_records_only_deleted_when_user_consents(self, mock_input):
+        responses = ['n', 'n', 'y', 'n']
+        mock_input.side_effect = lambda x: responses.pop()
+        records = self.get_mock_records()
+
+        pc.delete_records(records)
+
+        assert records[0].delete.call_count == 0
+        assert records[1].delete.call_count == 1
+        assert records[2].delete.call_count == 0
+        assert records[3].delete.call_count == 0
+
+    def get_mock_records(self):
+        records = []
+        for _ in range(4):
+            records.append(Mock())
+        return records
+
+
+# class TestUpdateExpectedScans:
+#
+#     def test_no_crash_if_site_undefined_in_config(self, config):
+#         pc.update_expected_scans(Mock(), 'BADSITE', config)
+#
+#     def test_no_crash_if_no_scans_defined_for_site(self, config):
+#         mock_study = Mock()
+#         mock_study.scantypes = {}
+#         pc.update_expected_scans(mock_study, 'NOSCANS', config)
+#
+#     def test_no_scantypes_added_if_none_defined_in_config(self, config):
+#         mock_study = Mock()
+#         mock_study.scantypes = {}
+#
+#         pc.update_expected_scans(mock_study, 'NOSCANS', config)
+#         assert mock_study.update_scantype.call_count == 0
+#
+#     @patch('bin.update_config.delete_records')
+#     def test_attempts_to_delete_database_scantypes_if_not_in_config(self,
+#             mock_delete, config):
+#         mock_study = Mock()
+#         mock_t1 = Mock()
+#         mock_t1.scantype_id = 'T1'
+#         mock_t2 = Mock()
+#         mock_t2.scantype_id = 'T2'
+#         mock_study.scantypes = {
+#             'SITE': [mock_t1, mock_t2]
+#         }
+#
+#         pc.update_expected_scans(mock_study, 'SITE', config)
+#         assert mock_delete.call_count == 1
+#         assert mock_delete.call_args_list[0].args[0][0] == mock_t2
+#
+#     def test_expected_tags_updated_in_database(self, config):
+#         mock_t1 = Mock()
+#         mock_t1.scantype_id = 'T1'
+#         mock_study = Mock()
+#         mock_study.scantypes = {
+#             'SITE': [mock_t1]
+#         }
+#
+#         pc.update_expected_scans(mock_study, 'SITE', config)
+#         assert mock_study.update_scantype.call_count == 1
+#         assert mock_study.update_scantype.call_args_list[0][0][1] == 'T1'
+#
+#     @pytest.fixture
+#     def config(self):
+#         tag_settings = {
+#             'T1': {
+#                 'formats': ['nii', 'dcm', 'mnc'],
+#                 'qc_type': 'anat',
+#                 'bids': {'class': 'anat', 'modality_label': 'T1w'},
+#                 'Pattern': {'SeriesDescription': ['T1', 'BRAVO']},
+#                 'Count': 1
+#             }
+#         }
+#
+#         def get_tags(name):
+#             if name == 'SITE':
+#                 return datman.config.TagInfo(tag_settings)
+#             if name == 'NOSCANS':
+#                 return datman.config.TagInfo({})
+#             raise datman.config.UndefinedSetting
+#
+#         config = Mock(spec="datman.config.config")
+#         config.get_tags.side_effect = get_tags
+#
+#         return config
+
+
+# class TestUpdateSite:
+#
+#     # @patch('bin.parse_config.update_expected_scans')
+#     # def test_no_crash_with_undefined_settings(self, mock_expected, config):
+#     #     pc.update_site(Mock(), 'CMH', config)
+#
+#     # def test_raises_exception_when_given_undefined_site(self, config):
+#     #     with pytest.raises(Exception):
+#     #         pc.update_site(Mock(), 'BADSITE', config)
+#     #
+#     # # @patch('bin.parse_config.update_expected_scans')
+#     # def test_study_record_updated_for_given_site(self, mock_expected, config):
+#     #     mock_study = Mock()
+#     #     pc.update_site(mock_study, 'CMH', config)
+#     #
+#     #     assert mock_study.update_site.call_count == 1
+#     #     assert mock_study.update_site.call_args_list[0][0][0] == 'CMH'
+#
+#     @patch('bin.update_config.update_expected_scans')
+#     def test_expected_scans_updated_for_site(self, mock_expected, config):
+#         mock_study = Mock()
+#         pc.update_site(mock_study, 'CMH', config)
+#
+#         mock_expected.assert_called_once_with(
+#             mock_study, 'CMH', config, False, False
+#         )
+#
+#     @pytest.fixture
+#     def config(self):
+#         sites = {
+#             'CMH': {
+#                 'STUDY_TAG': 'TST01'
+#             }
+#         }
+#         def get_key(key, site=None):
+#             if not site:
+#                 raise datman.config.UndefinedSetting
+#             try:
+#                 site_conf = sites[site]
+#             except KeyError:
+#                 raise datman.config.ConfigException
+#             try:
+#                 return site_conf[key]
+#             except KeyError:
+#                 raise datman.config.UndefinedSetting
+#
+#         config = Mock(spec="datman.config.config")
+#         config.get_key.side_effect = get_key
+#         return config
+
+
+class TestUpdateStudy:
+
+    def test_no_crash_when_study_undefined(self):
+        config = Mock(spec=datman.config.config)
+        def set_study(study):
+            raise datman.config.ConfigException
+        config.set_study = set_study
+        pc.update_study("BADSTUDY", config)
+
+    @patch('dashboard.queries')
+    def test_no_crash_when_sites_not_defined(self, mock_dash):
+        config = Mock(spec=datman.config.config)
+        def get_sites():
+            raise datman.config.UndefinedSetting
+        config.get_sites = get_sites
+        pc.update_study('STUDY', config)
+
+    # @patch('bin.parse_config.update_expected_scans')
+    # @patch('builtins.input')
+    # @patch('datman.dashboard')
+    # def test_site_records_deleted_if_no_longer_in_config(
+    #         self, mock_dash, mock_input, mock_expected):
+    #     mock_input.return_value = 'y'
+    #
+    #     config = Mock(spec="datman.config.config")
+    #     config.get_sites.return_value = ['CMH']
+    #
+    #     mock_study = Mock()
+    #     mock_study.sites = {
+    #         'CMH': Mock(),
+    #         'UTO': Mock()
+    #     }
+    #     def get_project(study, create=False):
+    #         return mock_study if study == 'STUDY' else None
+    #     mock_dash.get_project.side_effect = get_project
+    #
+    #     pc.update_study('STUDY', config)
+    #     mock_study.delete_site.assert_called_once_with('UTO')
+
+
+    @patch('bin.parse_config.update_site')
+    @patch('bin.parse_config.delete_records')
+    @patch('dashboard.queries')
+    def test_update_site_called_for_each_site_in_config(
+            self, mock_dash, mock_delete, mock_update_site):
+        mock_study = Mock()
+        mock_study.sites = {
+            'CMH': Mock(),
+            'UTO': Mock()
+        }
+        mock_dash.get_studies.return_value = mock_study
+
+        config = Mock(spec=datman.config.config)
+        config.get_key.return_value = False
+        config.get_sites.return_value = ['CMH']
+
+        pc.update_study('STUDY', config)
+        mock_update_site.assert_called_once_with(
+            mock_study, 'CMH', config, delete_all=False, skip_delete=False
+        )
+
+
+@patch('dashboard.queries')
+@patch('bin.parse_config.delete_records')
+@patch('bin.parse_config.update_study')
+class TestUpdateStudies:
+
+    def test_no_crash_when_studies_not_defined(self, mock_update, mock_delete,
+                mock_dash):
+        config = Mock(spec=datman.config.config)
+        def get_key(key):
+            raise datman.config.UndefinedSetting
+        config.get_key = get_key
+
+        pc.update_studies(config)
+
+    def test_creates_or_updates_each_study_found_in_config(self, mock_update,
+                mock_delete, mock_dash, config):
+        mock_dash.get_projects.return_value = []
+        pc.update_studies(config)
+        assert mock_update.call_count == len(config.get_key('Projects').keys())
+
+    def test_deletes_studies_not_defined_in_config(self, mock_update,
+                mock_delete, mock_dash, config):
+        mock_study = Mock()
+        mock_study.id = 'STUDY5'
+        mock_dash.get_studies.return_value = [mock_study]
+
+        pc.update_studies(config, delete_all=True)
+        assert mock_delete.call_count == 1
+        assert mock_delete.call_args_list[0][0][0] == [mock_study]
+
+    @pytest.fixture
+    def config(self, *args):
+        config = Mock(spec=datman.config.config)
+        config.get_key.side_effect = lambda x: {
+            'Projects': {
+                'STUDY1',
+                'STUDY2',
+                'STUDY3'
+            }
+        }
+        return config

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -315,16 +315,8 @@ class TestUpdateStudy:
     @patch('builtins.input')
     @patch('dashboard.queries')
     def test_site_records_deleted_if_no_longer_in_config(
-            self, mock_dash, mock_input, mock_expected):
+            self, mock_dash, mock_input, mock_expected, config):
         mock_input.return_value = 'y'
-
-        config = Mock(spec=datman.config.config)
-        config.get_sites.return_value = ['CMH']
-        def get_key(key, **kwargs):
-            if key == 'DbIgnore':
-                return False
-            return True
-        config.get_key = get_key
 
         mock_study = Mock()
         mock_study.sites = {
@@ -359,6 +351,28 @@ class TestUpdateStudy:
         mock_update_site.assert_called_once_with(
             mock_study, 'CMH', config, delete_all=False, skip_delete=False
         )
+
+    @pytest.fixture
+    def config(self):
+        def get_key(key, site=None, ignore_defaults=False,
+                    defaults_only=False):
+            try:
+                return {}[key]
+            except:
+                raise datman.config.UndefinedSetting
+
+        config = Mock(spec=datman.config.config)
+        config.get_key.side_effect = get_key
+
+        def get_path(path, study=None):
+            try:
+                return {}[path]
+            except:
+                raise datman.config.UndefinedSetting
+
+        config.get_sites.return_value = ['CMH']
+
+        return config
 
 
 @patch('dashboard.queries')

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -6,32 +6,32 @@ from mock import patch, Mock
 import datman.config
 import dashboard
 
-pc = importlib.import_module('bin.parse_config')
+pc = importlib.import_module("bin.parse_config")
 
 
 class TestPromptUser:
 
-    @patch('builtins.input')
+    @patch("builtins.input")
     def test_true_only_when_y_given(self, mock_input):
         user_input = [
-            '         ',
-            '',
-            'y',
-            'n',
+            "         ",
+            "",
+            "y",
+            "n",
         ]
 
         mock_input.side_effect = lambda x: user_input.pop()
 
-        assert pc.prompt_user('Test message') is False
-        assert pc.prompt_user('Test message') is True
-        assert pc.prompt_user('Test message') is False
-        assert pc.prompt_user('Test message') is False
+        assert pc.prompt_user("Test message") is False
+        assert pc.prompt_user("Test message") is True
+        assert pc.prompt_user("Test message") is False
+        assert pc.prompt_user("Test message") is False
 
-    @patch('builtins.input')
+    @patch("builtins.input")
     def test_raises_runtime_error_for_unexpected_response(self, mock_input):
-        mock_input.return_value = 'dfgsxcvqa'
+        mock_input.return_value = "dfgsxcvqa"
         with pytest.raises(RuntimeError):
-            pc.prompt_user('Test message')
+            pc.prompt_user("Test message")
 
 
 class TestUpdateTags:
@@ -43,23 +43,23 @@ class TestUpdateTags:
 
         updated_tags = dashboard.models.Scantype.query.all()
         assert len(updated_tags) == 1
-        assert updated_tags[0].tag == 'T1'
+        assert updated_tags[0].tag == "T1"
 
     def test_existing_tag_updated_when_config_settings_differ(
             self, dash_db, config):
-        t1 = dashboard.models.Scantype('T1')
-        t1.qc_type = 'func'
+        t1 = dashboard.models.Scantype("T1")
+        t1.qc_type = "func"
         dash_db.session.add(t1)
         dash_db.session.commit()
 
-        assert dashboard.models.Scantype.query.get('T1').qc_type == 'func'
+        assert dashboard.models.Scantype.query.get("T1").qc_type == "func"
         pc.update_tags(config)
-        assert dashboard.models.Scantype.query.get('T1').qc_type == 'anat'
+        assert dashboard.models.Scantype.query.get("T1").qc_type == "anat"
 
     def test_deletes_tag_record_if_not_defined_in_config_file(
             self, dash_db, config):
-        t1 = dashboard.models.Scantype('T1')
-        t2 = dashboard.models.Scantype('T2')
+        t1 = dashboard.models.Scantype("T1")
+        t2 = dashboard.models.Scantype("T2")
 
         for item in [t1, t2]:
             dash_db.session.add(item)
@@ -77,13 +77,13 @@ class TestUpdateTags:
         """
         def get_key(name, site=None, ignore_defaults=False,
                     defaults_only=False):
-            if name == 'ExportSettings':
+            if name == "ExportSettings":
                 return {
-                            'T1': {
-                                'Formats': ['nii', 'dcm', 'mnc'],
-                                'QcType': 'anat'
-                            },
-                        }
+                    "T1": {
+                        "Formats": ["nii", "dcm", "mnc"],
+                        "QcType": "anat"
+                    },
+                }
             raise datman.config.UndefinedSetting
 
         config = Mock(spec=datman.config.config)
@@ -104,34 +104,34 @@ class TestDeleteRecords:
 
     def test_delete_func_used_to_delete_when_provided(self, records):
         def delete_func(x):
-            if x.qc_type == 'rest':
+            if x.qc_type == "rest":
                 x.delete()
 
         pc.delete_records(records, delete_func=delete_func, delete_all=True)
         result = dashboard.models.Scantype.query.all()
 
         for record in result:
-            assert record.qc_type != 'rest'
+            assert record.qc_type != "rest"
 
         for record in records:
-            if record.qc_type != 'rest':
+            if record.qc_type != "rest":
                 assert record in result
 
-    @patch('builtins.input')
-    @patch('bin.parse_config.prompt_user')
+    @patch("builtins.input")
+    @patch("bin.parse_config.prompt_user")
     def test_prompt_changed_when_message_given(
             self, mock_prompt, mock_input, records):
-        mock_input.return_value = 'y'
+        mock_input.return_value = "y"
 
-        message = 'Testing prompt flag'
+        message = "Testing prompt flag"
         pc.delete_records(records, prompt=message)
         for call in mock_prompt.call_args_list:
             assert message in call.args[0]
 
-    @patch('builtins.input')
+    @patch("builtins.input")
     def test_records_only_deleted_when_user_consents(
             self, mock_input, records):
-        responses = ['n', 'y']
+        responses = ["n", "y"]
         mock_input.side_effect = lambda x: responses.pop()
 
         pc.delete_records(records)
@@ -142,11 +142,11 @@ class TestDeleteRecords:
 
     @pytest.fixture
     def records(self, dash_db):
-        t1 = dashboard.models.Scantype('T1')
-        t1.qc_type = 'anat'
+        t1 = dashboard.models.Scantype("T1")
+        t1.qc_type = "anat"
 
-        rest = dashboard.models.Scantype('REST')
-        rest.qc_type = 'func'
+        rest = dashboard.models.Scantype("REST")
+        rest.qc_type = "func"
 
         for item in [t1, rest]:
             dash_db.session.add(item)
@@ -158,48 +158,48 @@ class TestDeleteRecords:
 
 class TestUpdateSite:
 
-    study_tag = 'STU01'
+    study_tag = "STU01"
     redcap = True
     notes = True
-    archive_name = 'STU01_CMH'
-    convention = 'DATMAN'
+    archive_name = "STU01_CMH"
+    convention = "DATMAN"
 
     def test_no_crash_if_config_file_site_doesnt_define_all_settings(
             self, config, db_study):
-        pc.update_site(db_study, 'MISSING_CONF', config)
+        pc.update_site(db_study, "MISSING_CONF", config)
 
     def test_raises_exception_when_given_site_not_in_config_files(
             self, config, db_study):
         with pytest.raises(Exception):
-            pc.update_site(db_study, 'BAD_SITE', config)
+            pc.update_site(db_study, "BAD_SITE", config)
 
     def test_new_config_site_added_to_database_study(self, config, db_study):
         assert db_study.sites == {}
-        pc.update_site(db_study, 'CMH', config)
-        assert 'CMH' in db_study.sites
+        pc.update_site(db_study, "CMH", config)
+        assert "CMH" in db_study.sites
 
     def test_new_config_site_settings_all_added_to_database(
             self, config, db_study):
         assert db_study.sites == {}
-        pc.update_site(db_study, 'UT1', config)
+        pc.update_site(db_study, "UT1", config)
 
-        assert db_study.sites['UT1'].code == self.study_tag
-        assert db_study.sites['UT1'].uses_redcap == self.redcap
-        assert db_study.sites['UT1'].uses_notes == self.notes
-        assert db_study.sites['UT1'].xnat_archive == self.archive_name
-        assert db_study.sites['UT1'].xnat_convention == self.convention
+        assert db_study.sites["UT1"].code == self.study_tag
+        assert db_study.sites["UT1"].uses_redcap == self.redcap
+        assert db_study.sites["UT1"].uses_notes == self.notes
+        assert db_study.sites["UT1"].xnat_archive == self.archive_name
+        assert db_study.sites["UT1"].xnat_convention == self.convention
 
     def test_updates_settings_in_database_when_config_file_differs(
             self, config, db_study):
-        old_archive = 'wrong_archive'
-        db_study.update_site('CMH', xnat_archive=old_archive, create=True)
-        assert db_study.sites['CMH'].xnat_archive == old_archive
-        pc.update_site(db_study, 'CMH', config)
-        assert db_study.sites['CMH'].xnat_archive == self.archive_name
+        old_archive = "wrong_archive"
+        db_study.update_site("CMH", xnat_archive=old_archive, create=True)
+        assert db_study.sites["CMH"].xnat_archive == old_archive
+        pc.update_site(db_study, "CMH", config)
+        assert db_study.sites["CMH"].xnat_archive == self.archive_name
 
     @pytest.fixture
     def db_study(self, dash_db):
-        study = dashboard.models.Study('STUDY')
+        study = dashboard.models.Study("STUDY")
         dash_db.session.add(study)
         dash_db.session.commit()
         return study
@@ -207,16 +207,16 @@ class TestUpdateSite:
     @pytest.fixture
     def config(self):
         sites = {
-            'CMH': {
-                'XnatArchive': self.archive_name
+            "CMH": {
+                "XnatArchive": self.archive_name
             },
-            'MISSING_CONF': {},
-            'UT1': {
-                'StudyTag': self.study_tag,
-                'UsesRedcap': self.redcap,
-                'UsesTechNotes': self.notes,
-                'XnatArchive': self.archive_name,
-                'XnatConvention': self.convention
+            "MISSING_CONF": {},
+            "UT1": {
+                "StudyTag": self.study_tag,
+                "UsesRedcap": self.redcap,
+                "UsesTechNotes": self.notes,
+                "XnatArchive": self.archive_name,
+                "XnatConvention": self.convention
             }
         }
 
@@ -233,7 +233,7 @@ class TestUpdateSite:
                 raise datman.config.UndefinedSetting
 
         def get_tags(tag):
-            if tag == 'CMH':
+            if tag == "CMH":
                 return datman.config.TagInfo({})
             raise datman.config.UndefinedSetting
 
@@ -246,69 +246,69 @@ class TestUpdateSite:
 class TestUpdateExpectedScans:
 
     def test_no_crash_if_site_undefined_in_config(self, config, db_study):
-        pc.update_expected_scans(db_study, 'BADSITE', config)
+        pc.update_expected_scans(db_study, "BADSITE", config)
 
     def test_no_records_made_if_site_undefined_in_config(
             self, config, db_study):
         assert dashboard.models.ExpectedScan.query.all() == []
-        pc.update_expected_scans(db_study, 'BADSITE', config)
+        pc.update_expected_scans(db_study, "BADSITE", config)
         assert dashboard.models.ExpectedScan.query.all() == []
 
     def test_no_crash_if_no_tags_defined_for_site(self, config, db_study):
-        pc.update_expected_scans(db_study, 'NOTAGS', config)
+        pc.update_expected_scans(db_study, "NOTAGS", config)
 
     def test_no_scantypes_added_if_none_defined_in_site_config(
             self, config, db_study):
-        assert 'NOTAGS' not in db_study.scantypes
-        pc.update_expected_scans(db_study, 'NOTAGS', config)
-        assert 'NOTAGS' not in db_study.scantypes
+        assert "NOTAGS" not in db_study.scantypes
+        pc.update_expected_scans(db_study, "NOTAGS", config)
+        assert "NOTAGS" not in db_study.scantypes
 
     def test_deletes_db_scantype_if_not_in_site_config(self, config, db_study):
         dashboard.models.db.session.add(
-            dashboard.models.ExpectedScan('STUDY', 'NOTAGS', 'T1')
+            dashboard.models.ExpectedScan("STUDY", "NOTAGS", "T1")
         )
         dashboard.models.db.session.commit()
 
-        assert len(db_study.scantypes['NOTAGS']) == 1
-        pc.update_expected_scans(db_study, 'NOTAGS', config, delete_all=True)
+        assert len(db_study.scantypes["NOTAGS"]) == 1
+        pc.update_expected_scans(db_study, "NOTAGS", config, delete_all=True)
         assert db_study.scantypes == {}
 
     def test_expected_scans_updated_with_tag_defined_in_config(
             self, config, db_study):
         assert db_study.scantypes == {}
-        pc.update_expected_scans(db_study, 'SITE1', config)
-        assert 'SITE1' in db_study.scantypes
-        assert len(db_study.scantypes['SITE1']) == 1
-        assert db_study.scantypes['SITE1'][0].scantype_id == 'T1'
+        pc.update_expected_scans(db_study, "SITE1", config)
+        assert "SITE1" in db_study.scantypes
+        assert len(db_study.scantypes["SITE1"]) == 1
+        assert db_study.scantypes["SITE1"][0].scantype_id == "T1"
 
     @pytest.fixture
     def db_study(self, dash_db):
-        study = dashboard.models.Study('STUDY')
+        study = dashboard.models.Study("STUDY")
         dash_db.session.add(study)
-        dash_db.session.add(dashboard.models.Site('SITE1'))
-        dash_db.session.add(dashboard.models.StudySite('STUDY', 'SITE1'))
-        dash_db.session.add(dashboard.models.Site('NOTAGS'))
-        dash_db.session.add(dashboard.models.StudySite('STUDY', 'NOTAGS'))
-        dash_db.session.add(dashboard.models.Scantype('T1'))
+        dash_db.session.add(dashboard.models.Site("SITE1"))
+        dash_db.session.add(dashboard.models.StudySite("STUDY", "SITE1"))
+        dash_db.session.add(dashboard.models.Site("NOTAGS"))
+        dash_db.session.add(dashboard.models.StudySite("STUDY", "NOTAGS"))
+        dash_db.session.add(dashboard.models.Scantype("T1"))
         dash_db.session.commit()
         return study
 
     @pytest.fixture
     def config(self):
         tag_settings = {
-            'T1': {
-                'formats': ['nii', 'dcm', 'mnc'],
-                'qc_type': 'anat',
-                'bids': {'class': 'anat', 'modality_label': 'T1w'},
-                'Pattern': {'SeriesDescription': ['T1', 'BRAVO']},
-                'Count': 1
+            "T1": {
+                "formats": ["nii", "dcm", "mnc"],
+                "qc_type": "anat",
+                "bids": {"class": "anat", "modality_label": "T1w"},
+                "Pattern": {"SeriesDescription": ["T1", "BRAVO"]},
+                "Count": 1
             }
         }
 
         def get_tags(name):
-            if name == 'SITE1':
+            if name == "SITE1":
                 return datman.config.TagInfo(tag_settings)
-            if name == 'NOTAGS':
+            if name == "NOTAGS":
                 return datman.config.TagInfo({})
             raise datman.config.UndefinedSetting
 
@@ -324,44 +324,44 @@ class TestUpdateStudy:
         def set_study(study):
             raise datman.config.ConfigException
         config.set_study = set_study
-        pc.update_study('BADSTUDY', config, skip_delete=True)
+        pc.update_study("BADSTUDY", config, skip_delete=True)
 
     def test_no_crash_when_no_sites_defined_in_config(self, config, dash_db):
         def get_sites():
             raise datman.config.UndefinedSetting
         config.get_sites = get_sites
-        pc.update_study('SPINS', config, skip_delete=True)
+        pc.update_study("SPINS", config, skip_delete=True)
 
     def test_site_records_deleted_if_no_longer_in_config(
             self, config, db_study):
         assert len(db_study.sites) == 2
-        assert 'UT2' in db_study.sites
-        pc.update_study('SPINS', config, delete_all=True)
+        assert "UT2" in db_study.sites
+        pc.update_study("SPINS", config, delete_all=True)
         assert len(db_study.sites) == 1
-        assert 'UT2' not in db_study.sites
+        assert "UT2" not in db_study.sites
 
     def test_db_study_unchanged_if_config_file_sets_DbIgnore(
             self, config, db_study):
         def get_key(key, site=None, ignore_defaults=False):
-            if key in ['DbIgnore', 'IsOpen']:
+            if key in ["DbIgnore", "IsOpen"]:
                 return True
             raise datman.config.UndefinedSetting
         config.get_key = get_key
 
         assert db_study.is_open is False
-        pc.update_study('SPINS', config, skip_delete=True)
+        pc.update_study("SPINS", config, skip_delete=True)
         assert db_study.is_open is False
 
     def test_study_is_created_in_database_if_doesnt_already_exist(
             self, config, dash_db):
         assert dashboard.models.Study.query.all() == []
-        pc.update_study('SPINS', config, skip_delete=True)
-        assert dashboard.models.Study.query.get('SPINS') is not None
+        pc.update_study("SPINS", config, skip_delete=True)
+        assert dashboard.models.Study.query.get("SPINS") is not None
 
-    @patch('bin.parse_config.update_site')
+    @patch("bin.parse_config.update_site")
     def test_updating_study_calls_update_site_for_configured_sites(
             self, mock_update, config, db_study):
-        pc.update_study('SPINS', config, skip_delete=True)
+        pc.update_study("SPINS", config, skip_delete=True)
         assert mock_update.call_count == len(config.get_sites())
 
     @pytest.fixture
@@ -374,7 +374,7 @@ class TestUpdateStudy:
             raise datman.config.UndefinedSetting
 
         def get_tags(tag):
-            if tag == 'CMH':
+            if tag == "CMH":
                 return datman.config.TagInfo({})
             raise datman.config.UndefinedSetting
 
@@ -382,17 +382,17 @@ class TestUpdateStudy:
         config.get_key = get_key
         config.get_path = get_path
         config.get_tags = get_tags
-        config.get_sites.return_value = ['CMH']
+        config.get_sites.return_value = ["CMH"]
         return config
 
     @pytest.fixture
     def db_study(self, dash_db):
-        study = dashboard.models.Study('SPINS')
+        study = dashboard.models.Study("SPINS")
         study.is_open = False
         dash_db.session.add(study)
         dash_db.session.commit()
-        study.update_site('CMH', create=True)
-        study.update_site('UT2', create=True)
+        study.update_site("CMH", create=True)
+        study.update_site("UT2", create=True)
         return study
 
 
@@ -407,28 +407,28 @@ class TestUpdateStudies:
 
     def test_creates_or_updates_each_study_found_in_config(
             self, config, dash_db):
-        assert len(config.get_key('Projects')) > 0
+        assert len(config.get_key("Projects")) > 0
         pc.update_studies(config)
-        for study in config.get_key('Projects'):
+        for study in config.get_key("Projects"):
             assert dashboard.models.Study.query.get(study) is not None
 
     def test_deletes_studies_not_defined_in_config(self, config, dash_db):
-        extra_study = dashboard.models.Study('STUDY5')
+        extra_study = dashboard.models.Study("STUDY5")
         dash_db.session.add(extra_study)
         dash_db.session.commit()
 
-        assert dashboard.models.Study.query.get('STUDY5') is not None
+        assert dashboard.models.Study.query.get("STUDY5") is not None
         pc.update_studies(config, delete_all=True)
-        assert dashboard.models.Study.query.get('STUDY5') is None
+        assert dashboard.models.Study.query.get("STUDY5") is None
 
     @pytest.fixture
     def config(self):
         def get_key(key, site=None, *kwargs):
-            if key == 'Projects':
+            if key == "Projects":
                 return {
-                    'STUDY1': 'study1_settings.yml',
-                    'STUDY2': 'study2_settings.yml',
-                    'STUDY3': 'study3_settings.yml'
+                    "STUDY1": "study1_settings.yml",
+                    "STUDY2": "study2_settings.yml",
+                    "STUDY3": "study3_settings.yml"
                 }
             raise datman.config.UndefinedSetting
         config = Mock(spec=datman.config.config)

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -173,125 +173,125 @@ class TestDeleteRecords:
         return records
 
 
-# class TestUpdateExpectedScans:
-#
-#     def test_no_crash_if_site_undefined_in_config(self, config):
-#         pc.update_expected_scans(Mock(), 'BADSITE', config)
-#
-#     def test_no_crash_if_no_scans_defined_for_site(self, config):
-#         mock_study = Mock()
-#         mock_study.scantypes = {}
-#         pc.update_expected_scans(mock_study, 'NOSCANS', config)
-#
-#     def test_no_scantypes_added_if_none_defined_in_config(self, config):
-#         mock_study = Mock()
-#         mock_study.scantypes = {}
-#
-#         pc.update_expected_scans(mock_study, 'NOSCANS', config)
-#         assert mock_study.update_scantype.call_count == 0
-#
-#     @patch('bin.update_config.delete_records')
-#     def test_attempts_to_delete_database_scantypes_if_not_in_config(self,
-#             mock_delete, config):
-#         mock_study = Mock()
-#         mock_t1 = Mock()
-#         mock_t1.scantype_id = 'T1'
-#         mock_t2 = Mock()
-#         mock_t2.scantype_id = 'T2'
-#         mock_study.scantypes = {
-#             'SITE': [mock_t1, mock_t2]
-#         }
-#
-#         pc.update_expected_scans(mock_study, 'SITE', config)
-#         assert mock_delete.call_count == 1
-#         assert mock_delete.call_args_list[0].args[0][0] == mock_t2
-#
-#     def test_expected_tags_updated_in_database(self, config):
-#         mock_t1 = Mock()
-#         mock_t1.scantype_id = 'T1'
-#         mock_study = Mock()
-#         mock_study.scantypes = {
-#             'SITE': [mock_t1]
-#         }
-#
-#         pc.update_expected_scans(mock_study, 'SITE', config)
-#         assert mock_study.update_scantype.call_count == 1
-#         assert mock_study.update_scantype.call_args_list[0][0][1] == 'T1'
-#
-#     @pytest.fixture
-#     def config(self):
-#         tag_settings = {
-#             'T1': {
-#                 'formats': ['nii', 'dcm', 'mnc'],
-#                 'qc_type': 'anat',
-#                 'bids': {'class': 'anat', 'modality_label': 'T1w'},
-#                 'Pattern': {'SeriesDescription': ['T1', 'BRAVO']},
-#                 'Count': 1
-#             }
-#         }
-#
-#         def get_tags(name):
-#             if name == 'SITE':
-#                 return datman.config.TagInfo(tag_settings)
-#             if name == 'NOSCANS':
-#                 return datman.config.TagInfo({})
-#             raise datman.config.UndefinedSetting
-#
-#         config = Mock(spec="datman.config.config")
-#         config.get_tags.side_effect = get_tags
-#
-#         return config
+class TestUpdateExpectedScans:
+
+    def test_no_crash_if_site_undefined_in_config(self, config):
+        pc.update_expected_scans(Mock(), 'BADSITE', config)
+
+    def test_no_crash_if_no_scans_defined_for_site(self, config):
+        mock_study = Mock()
+        mock_study.scantypes = {}
+        pc.update_expected_scans(mock_study, 'NOSCANS', config)
+
+    def test_no_scantypes_added_if_none_defined_in_config(self, config):
+        mock_study = Mock()
+        mock_study.scantypes = {}
+
+        pc.update_expected_scans(mock_study, 'NOSCANS', config)
+        assert mock_study.update_scantype.call_count == 0
+
+    @patch('bin.parse_config.delete_records')
+    def test_attempts_to_delete_database_scantypes_if_not_in_config(self,
+            mock_delete, config):
+        mock_study = Mock()
+        mock_t1 = Mock()
+        mock_t1.scantype_id = 'T1'
+        mock_t2 = Mock()
+        mock_t2.scantype_id = 'T2'
+        mock_study.scantypes = {
+            'SITE': [mock_t1, mock_t2]
+        }
+
+        pc.update_expected_scans(mock_study, 'SITE', config)
+        assert mock_delete.call_count == 1
+        assert mock_delete.call_args_list[0].args[0][0] == mock_t2
+
+    def test_expected_tags_updated_in_database(self, config):
+        mock_t1 = Mock()
+        mock_t1.scantype_id = 'T1'
+        mock_study = Mock()
+        mock_study.scantypes = {
+            'SITE': [mock_t1]
+        }
+
+        pc.update_expected_scans(mock_study, 'SITE', config)
+        assert mock_study.update_scantype.call_count == 1
+        assert mock_study.update_scantype.call_args_list[0][0][1] == 'T1'
+
+    @pytest.fixture
+    def config(self):
+        tag_settings = {
+            'T1': {
+                'formats': ['nii', 'dcm', 'mnc'],
+                'qc_type': 'anat',
+                'bids': {'class': 'anat', 'modality_label': 'T1w'},
+                'Pattern': {'SeriesDescription': ['T1', 'BRAVO']},
+                'Count': 1
+            }
+        }
+
+        def get_tags(name):
+            if name == 'SITE':
+                return datman.config.TagInfo(tag_settings)
+            if name == 'NOSCANS':
+                return datman.config.TagInfo({})
+            raise datman.config.UndefinedSetting
+
+        config = Mock(spec=datman.config.config)
+        config.get_tags.side_effect = get_tags
+
+        return config
 
 
-# class TestUpdateSite:
-#
-#     # @patch('bin.parse_config.update_expected_scans')
-#     # def test_no_crash_with_undefined_settings(self, mock_expected, config):
-#     #     pc.update_site(Mock(), 'CMH', config)
-#
-#     # def test_raises_exception_when_given_undefined_site(self, config):
-#     #     with pytest.raises(Exception):
-#     #         pc.update_site(Mock(), 'BADSITE', config)
-#     #
-#     # # @patch('bin.parse_config.update_expected_scans')
-#     # def test_study_record_updated_for_given_site(self, mock_expected, config):
-#     #     mock_study = Mock()
-#     #     pc.update_site(mock_study, 'CMH', config)
-#     #
-#     #     assert mock_study.update_site.call_count == 1
-#     #     assert mock_study.update_site.call_args_list[0][0][0] == 'CMH'
-#
-#     @patch('bin.update_config.update_expected_scans')
-#     def test_expected_scans_updated_for_site(self, mock_expected, config):
-#         mock_study = Mock()
-#         pc.update_site(mock_study, 'CMH', config)
-#
-#         mock_expected.assert_called_once_with(
-#             mock_study, 'CMH', config, False, False
-#         )
-#
-#     @pytest.fixture
-#     def config(self):
-#         sites = {
-#             'CMH': {
-#                 'STUDY_TAG': 'TST01'
-#             }
-#         }
-#         def get_key(key, site=None):
-#             if not site:
-#                 raise datman.config.UndefinedSetting
-#             try:
-#                 site_conf = sites[site]
-#             except KeyError:
-#                 raise datman.config.ConfigException
-#             try:
-#                 return site_conf[key]
-#             except KeyError:
-#                 raise datman.config.UndefinedSetting
-#
-#         config = Mock(spec="datman.config.config")
-#         config.get_key.side_effect = get_key
-#         return config
+class TestUpdateSite:
+
+    @patch('bin.parse_config.update_expected_scans')
+    def test_no_crash_with_undefined_settings(self, mock_expected, config):
+        pc.update_site(Mock(), 'CMH', config)
+
+    def test_raises_exception_when_given_undefined_site(self, config):
+        with pytest.raises(Exception):
+            pc.update_site(Mock(), 'BADSITE', config)
+
+    @patch('bin.parse_config.update_expected_scans')
+    def test_study_record_updated_for_given_site(self, mock_expected, config):
+        mock_study = Mock()
+        pc.update_site(mock_study, 'CMH', config)
+
+        assert mock_study.update_site.call_count == 1
+        assert mock_study.update_site.call_args_list[0][0][0] == 'CMH'
+
+    @patch('bin.parse_config.update_expected_scans')
+    def test_expected_scans_updated_for_site(self, mock_expected, config):
+        mock_study = Mock()
+        pc.update_site(mock_study, 'CMH', config)
+
+        mock_expected.assert_called_once_with(
+            mock_study, 'CMH', config, False, False
+        )
+
+    @pytest.fixture
+    def config(self):
+        sites = {
+            'CMH': {
+                'STUDY_TAG': 'TST01'
+            }
+        }
+        def get_key(key, site=None):
+            if not site:
+                raise datman.config.UndefinedSetting
+            try:
+                site_conf = sites[site]
+            except KeyError:
+                raise datman.config.ConfigException
+            try:
+                return site_conf[key]
+            except KeyError:
+                raise datman.config.UndefinedSetting
+
+        config = Mock(spec=datman.config.config)
+        config.get_key = get_key
+        return config
 
 
 class TestUpdateStudy:
@@ -311,27 +311,32 @@ class TestUpdateStudy:
         config.get_sites = get_sites
         pc.update_study('STUDY', config)
 
-    # @patch('bin.parse_config.update_expected_scans')
-    # @patch('builtins.input')
-    # @patch('datman.dashboard')
-    # def test_site_records_deleted_if_no_longer_in_config(
-    #         self, mock_dash, mock_input, mock_expected):
-    #     mock_input.return_value = 'y'
-    #
-    #     config = Mock(spec="datman.config.config")
-    #     config.get_sites.return_value = ['CMH']
-    #
-    #     mock_study = Mock()
-    #     mock_study.sites = {
-    #         'CMH': Mock(),
-    #         'UTO': Mock()
-    #     }
-    #     def get_project(study, create=False):
-    #         return mock_study if study == 'STUDY' else None
-    #     mock_dash.get_project.side_effect = get_project
-    #
-    #     pc.update_study('STUDY', config)
-    #     mock_study.delete_site.assert_called_once_with('UTO')
+    @patch('bin.parse_config.update_expected_scans')
+    @patch('builtins.input')
+    @patch('dashboard.queries')
+    def test_site_records_deleted_if_no_longer_in_config(
+            self, mock_dash, mock_input, mock_expected):
+        mock_input.return_value = 'y'
+
+        config = Mock(spec=datman.config.config)
+        config.get_sites.return_value = ['CMH']
+        def get_key(key, **kwargs):
+            if key == 'DbIgnore':
+                return False
+            return True
+        config.get_key = get_key
+
+        mock_study = Mock()
+        mock_study.sites = {
+            'CMH': Mock(),
+            'UTO': Mock()
+        }
+        def get_studies(study, create=False):
+            return [mock_study] if study == 'STUDY' else []
+        mock_dash.get_studies = get_studies
+
+        pc.update_study('STUDY', config)
+        mock_study.delete_site.assert_called_once_with('UTO')
 
 
     @patch('bin.parse_config.update_site')
@@ -344,7 +349,7 @@ class TestUpdateStudy:
             'CMH': Mock(),
             'UTO': Mock()
         }
-        mock_dash.get_studies.return_value = mock_study
+        mock_dash.get_studies.return_value = [mock_study]
 
         config = Mock(spec=datman.config.config)
         config.get_key.return_value = False


### PR DESCRIPTION
First off, let me say sorry that this got so big and disorganized! I had to split this off from another branch that got really out of hand. I'll work harder to keep things small and organized in the future.

This PR adds:

- `bin/parse_config.py` which can be run by a user with permissions to modify the database to read and update all study, site and tag related settings in the database. It also prompts the user for permission to remove records in the database that are no longer defined in the config files (e.g. if a tag was renamed at some point it can purge the old tag and references to it from the database).
- `tests/test_parse_config.py` and `tests/conftest.py` for unit testing parse_config
- An 'expected scans' relationship to track how many of scans with each tag should be found for each study / site pair
- Some dashboard.queries functions to act as an interface to update study and site settings without touching the models directly
- A migration script to handle the changes to the models 
- A `POSTGRES_TEST_DATABASE` env var the user can set to name the test database that will be used when running `tests/test_parse_config.py` and a documentation entry for this setting.
