### PR TITLE
[FIX] Allow redcap session IDs to contain whitespace and fix regression

### DIFF
--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -131,7 +131,7 @@ def create_from_request(request):
 
 
 def set_session(name):
-    name = name.upper()
+    name = name.strip().upper()
     try:
         ident = datman.scanid.parse(name)
     except datman.scanid.ParseException:

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -159,8 +159,6 @@ def find_study(ident):
 def get_timepoint(ident):
     timepoint = Timepoint.query.get(ident.get_full_subjectid_with_timepoint())
     if not timepoint:
-        study = find_study(ident)
-        if isinstance(study, list):
-            study = study[0].study
+        study = find_study(ident)[0]
         timepoint = study.add_timepoint(ident)
     return timepoint

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+import dashboard
+import dashboard.blueprints.redcap.utils as rc_utils
+import datman.scanid
+
+
+class TestGetTimepoint:
+
+    def test_can_find_timepoint_by_datman_ident(self, study, ident):
+        study.add_timepoint(ident)
+
+        tp = rc_utils.get_timepoint(ident)
+
+        assert tp is not None
+        assert tp.name == ident.get_full_subjectid_with_timepoint()
+        assert study.id in tp.studies
+
+    def test_creates_timepoint_if_doesnt_exist(self, study, ident):
+        tp = rc_utils.get_timepoint(ident)
+
+        assert tp is not None
+        assert tp.name == ident.get_full_subjectid_with_timepoint()
+        assert study.id in tp.studies
+
+    @pytest.fixture
+    def study(self, dash_db):
+        study = dashboard.models.Study("STUDY01")
+        dash_db.session.add(study)
+        study.update_site("CMH", code="STU01", create=True)
+        return study
+
+    @pytest.fixture
+    def ident(self):
+        return datman.scanid.parse("STU01_CMH_0001_01_01")

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -5,6 +5,39 @@ import dashboard.blueprints.redcap.utils as rc_utils
 import datman.scanid
 
 
+class TestSetSession:
+
+    def test_valid_id_returns_a_dashboard_session_record(self, records):
+        name = "STU01_CMH_0001_01_01"
+        session = rc_utils.set_session(name)
+        assert str(session) == name
+
+    def test_valid_id_with_space_padding_is_accepted(self, dash_db):
+        name = " STU01_CMH_0001_01_01 "
+        session = rc_utils.set_session(name)
+        assert session is not None
+        assert str(session) == name.strip()
+
+    def test_id_with_undefined_site_raises_exception(self, dash_db):
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.set_session("STU01_ABC_0001_01_01")
+
+    def test_id_with_undefined_study_raises_exception(self, dash_db):
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.set_session("AAA00_CMH_0001_01_01")
+
+    def test_id_with_unexpected_format_raises_exception(self, dash_db):
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.set_session("STUDYCMH-1000")
+
+    @pytest.fixture
+    def records(self, dash_db):
+        study = dashboard.models.Study("STUDY1")
+        dash_db.session.add(study)
+        study.update_site("CMH", code="STU01", create=True)
+        return [study]
+
+
 class TestGetTimepoint:
 
     def test_can_find_timepoint_by_datman_ident(self, study, ident):

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -12,7 +12,7 @@ class TestSetSession:
         session = rc_utils.set_session(name)
         assert str(session) == name
 
-    def test_valid_id_with_space_padding_is_accepted(self, dash_db):
+    def test_valid_id_with_space_padding_is_accepted(self, records):
         name = " STU01_CMH_0001_01_01 "
         session = rc_utils.set_session(name)
         assert session is not None


### PR DESCRIPTION
This PR addresses an issue @kyjimmy  discovered, where preceding whitespace was stopping valid IDs from being accepted when the redcap DET was received, and fixes a regression discovered during testing.

- Add tests describing correct behavior for redcap.utils.get_timepoint 38491afe990c535dc7d5b9c2af8d2eb3008fe9b5
- Fix regression in redcap.utils.get_timepoint. The recent changes to dashboard.queries.find_studies mean that Study objects are now returned instead of the StudySite object this function was expecting. This caused an exception every time a new timepoint had to be made. e6746a4142275ffdd5abdf64bb551fff0712b6c7
- Add tests describing correct behavior for redcap.utils.set_session 1ea263444ccc9c35fc47d530aee7160632470083, 33902e4c7ba2e6ef8c7b1521c7cb798456bc023b
- Update set_session so that preceding/following white space is stripped off before the ID from redcap gets parsed 3e4aec27762f9f9f6c140e6240a1eb2f51fb688d