### PR TITLE
[FIX] Start updating redcap record event IDs

### DIFF
--- a/bin/parse_config.py
+++ b/bin/parse_config.py
@@ -234,6 +234,7 @@ def update_redcap(config):
     update_setting(rc_config, "session_id_field", config, "RedcapSubj")
     update_setting(rc_config, "completed_field", config, "RedcapStatus")
     update_setting(rc_config, "completed_value", config, "RedcapStatusValue")
+    update_setting(rc_config, "event_ids", config, "RedcapEventId")
     rc_config.save()
 
 

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -65,8 +65,12 @@ def create_from_request(request):
 
     if 'redcap_event_name' in request.form:
         event_name = request.form['redcap_event_name']
+        event_id = (
+            cfg.event_ids[event_name] if event_name in cfg.event_ids else None
+        )
     else:
         event_name = None
+        event_id = None
 
     rc = REDCAP.Project(url + 'api/', cfg.token)
     server_record = rc.export_records([record])
@@ -113,7 +117,7 @@ def create_from_request(request):
     try:
         new_record = session.add_redcap(
             record, date, config=cfg.id, rc_user=redcap_user, comment=comment,
-            redcap_version=version
+            redcap_version=version, event_id=event_id
         )
     except Exception as e:
         raise RedcapException("Failed adding record {} from project {} on "

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -112,7 +112,8 @@ def create_from_request(request):
 
     try:
         new_record = session.add_redcap(
-            record, date, config=cfg.id, rc_user=redcap_user, comment=comment
+            record, date, config=cfg.id, rc_user=redcap_user, comment=comment,
+            redcap_version=version
         )
     except Exception as e:
         raise RedcapException("Failed adding record {} from project {} on "

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -66,7 +66,7 @@ def create_from_request(request):
     if 'redcap_event_name' in request.form:
         event_name = request.form['redcap_event_name']
         event_id = (
-            cfg.event_ids[event_name] if event_name in cfg.event_ids else None
+            cfg.event_ids.get(event_name) if cfg.event_ids else None
         )
     else:
         event_name = None

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -2054,11 +2054,15 @@ class RedcapRecord(db.Model):
         date,
         name='redcap_records_unique_record'), )
 
-    def __init__(self, record, config_id, date, version):
+    def __init__(self, record, config_id, date, redcap_version=None):
         self.record = record
         self.form_config = config_id
         self.date = date
-        self.redcap_version = version
+        if redcap_version:
+            # Add to session to populate the config, or setting version fails
+            db.session.add(self)
+            db.session.flush()
+            self.redcap_version = redcap_version
 
     @property
     def url(self):
@@ -2075,6 +2079,10 @@ class RedcapRecord(db.Model):
     @property
     def redcap_version(self):
         return self.config.redcap_version
+
+    @redcap_version.setter
+    def redcap_version(self, value):
+        self.config.redcap_version = value
 
     @property
     def is_shared(self):

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1397,7 +1397,7 @@ class Session(TableMixin, db.Model):
 
         cfg = RedcapConfig.get_config(
             config_id=config, project=project, instrument=instrument, url=url,
-            create=True, version=redcap_version
+            create=True
         )
 
         if self.redcap_record:

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -2100,7 +2100,7 @@ class RedcapConfig(TableMixin, db.Model):
     session_id_field = db.Column('session_id_field', db.String(128))
     completed_field = db.Column('completed_form_field', db.String(128))
     completed_value = db.Column('completed_value', db.String(10))
-
+    event_ids = db.Column('event_ids', JSONB)
     token = db.Column('token', db.String(64))
 
     records = db.relationship('RedcapRecord', back_populates='config')

--- a/migrations/versions/b68a8193acad_.py
+++ b/migrations/versions/b68a8193acad_.py
@@ -1,0 +1,30 @@
+"""Add a column to RedcapConfig to track event name to event ID mappings.
+
+Revision ID: b68a8193acad
+Revises: 77bce5fefcf4
+Create Date: 2022-02-08 21:40:46.276639
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'b68a8193acad'
+down_revision = '77bce5fefcf4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'redcap_config',
+        sa.Column(
+            'event_ids',
+            postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        )
+    )
+
+
+def downgrade():
+    op.drop_column('redcap_config', 'event_ids')

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import Mock, patch
 
 import dashboard
 import dashboard.blueprints.redcap.utils as rc_utils
@@ -66,3 +67,250 @@ class TestGetTimepoint:
     @pytest.fixture
     def ident(self):
         return datman.scanid.parse("STU01_CMH_0001_01_01")
+
+
+@patch("dashboard.blueprints.redcap.utils.monitor_scan_import")
+@patch("redcap.Project")
+class TestCreateFromRequest:
+
+    record_id = "100"
+    event_name = "baseline_other_arm_1"
+    session = "STU01_ABC_1111_01_01"
+    comment = "Scan went ok"
+    date = "2022-02-10"
+    pid = 9999
+    instrument = "mri_scan_log"
+    url = "https://fake.website.ca/redcap/"
+    version = "10.0.0"
+    date_field = "date"
+    comment_field = "cmts"
+    session_field = "par_id"
+    completed_field = "mri_scan_log_complete"
+    completed_value = "2"
+    event_ids = {
+        event_name: 12345,
+        "other_event": 54321
+    }
+    token = "AAAAAAAAAAAAAAAAAAAAAAAAA"
+    redcap_records = [{
+        "redcap_event_name": event_name,
+        completed_field: completed_value,
+        date_field: date,
+        comment_field: comment,
+        session_field: session
+    }]
+
+    def test_raises_exception_when_malformed_request_received(
+            self, mock_http, mock_monitor, det, records):
+        del det.form["project_id"]
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.create_from_request(det)
+
+    def test_no_records_added_when_matching_redcap_config_not_found(
+            self, mock_http, mock_monitor, det, records):
+        det.form["project_id"] = "0001"
+        assert det.form["project_id"] != self.pid
+
+        before_det = self.get_db_records()
+        rc_utils.create_from_request(det)
+        after_det = self.get_db_records()
+
+        assert mock_http.call_count == 0
+        for idx in range(len(before_det)):
+            assert before_det[idx] == after_det[idx]
+
+    def test_no_records_added_when_form_not_complete(
+            self, mock_http, mock_monitor, det, dash_db):
+        det.form[self.completed_field] = "1"
+
+        for item in self.get_db_records():
+            assert item == [], "Error - Database not empty before test ran."
+
+        rc_utils.create_from_request(det)
+
+        assert mock_http.call_count == 0
+        for item in self.get_db_records():
+            assert item == [], "Error - New data was added to database."
+
+    def test_exception_raised_if_multiple_redcap_records_match(
+            self, mock_http, mock_monitor, det, records):
+        export_output = []
+        export_output.extend(self.redcap_records)
+        export_output.append({
+            "record": self.record_id,
+            "redcap_event_name": self.event_name
+        })
+        mock_http.return_value = self.mock_redcap_export(export_output)
+
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.create_from_request(det)
+
+    def test_exception_raised_if_record_not_found_on_server(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export([])
+        with pytest.raises(dashboard.exceptions.RedcapException):
+            rc_utils.create_from_request(det)
+
+    def test_adds_redcap_record_to_session(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+        session = dashboard.models.Session.query.get((self.session[:-3], 1))
+        assert session.redcap_record is None
+
+        rc_utils.create_from_request(det)
+
+        assert session.redcap_record is not None
+        assert session.redcap_record.record.comment == self.comment
+
+    def test_adds_session_if_doesnt_exist(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+
+        timepoint = self.session[:-3]
+        session = dashboard.models.Session.query.get((timepoint, 1))
+        if session:
+            session.delete()
+        assert dashboard.models.Session.query.get((timepoint, 1)) is None
+        rc_utils.create_from_request(det)
+
+        session = dashboard.models.Session.query.get((timepoint, 1))
+        assert session is not None
+
+    def test_updates_redcap_record_if_updates_on_server(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+
+        # Add a redcap record
+        rc_utils.create_from_request(det)
+
+        # Modify the comment on the 'server'
+        new_comment = "Scan was NOT ok."
+        new_record = self.redcap_records[0].copy()
+        new_record[self.comment_field] = new_comment
+        mock_http.return_value = self.mock_redcap_export([new_record])
+
+        # Resend the data entry trigger
+        rc_utils.create_from_request(det)
+
+        session = dashboard.models.Session.query.get((self.session[:-3], 1))
+        assert session is not None
+        assert session.redcap_record.record.comment == new_comment
+
+    def test_sets_event_id_of_redcap_record(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+        rc_utils.create_from_request(det)
+
+        session = dashboard.models.Session.query.get((self.session[:-3], 1))
+        assert session.redcap_record is not None
+        db_record = session.redcap_record.record
+
+        assert db_record.event_id == self.event_ids[self.event_name]
+
+    def test_det_with_newer_version_causes_redcap_config_version_update(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+
+        redcap_config = dashboard.models.RedcapConfig.get_config(
+            project=self.pid,
+            instrument=self.instrument,
+            url=self.url
+        )
+        assert redcap_config is not None
+        assert redcap_config.redcap_version != self.version
+
+        rc_utils.create_from_request(det)
+
+        assert redcap_config.redcap_version == self.version
+
+    def test_calls_monitor_scan_import_for_session(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+        rc_utils.create_from_request(det)
+
+        session = dashboard.models.Session.query.get((self.session[:-3], 1))
+        assert mock_monitor.called_once_with(session)
+
+    @patch("dashboard.blueprints.redcap.utils.monitor_scan_download")
+    def test_calls_monitor_scan_download_if_download_script_is_set(
+            self, mock_download, mock_http, mock_scan_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+
+        study_site = dashboard.models.StudySite.query.get(("STUDY", "ABC"))
+        study_site.download_script = "/some/path/post_download.sh"
+        dashboard.models.db.session.add(study_site)
+        dashboard.models.db.session.commit()
+
+        rc_utils.create_from_request(det)
+
+        session = dashboard.models.Session.query.get((self.session[:-3], 1))
+        assert mock_download.called_once_with(session)
+
+    def mock_redcap_export(self, records=None):
+        def export_records(id_list):
+            if id_list == [self.record_id]:
+                if records is not None:
+                    return records
+                return self.redcap_records
+            return []
+        mock_rc = Mock()
+        mock_rc.export_records = export_records
+        return mock_rc
+
+    def get_db_records(self):
+        """Get all records from tables that may be modified.
+        """
+        return [
+            dashboard.models.RedcapRecord.query.all(),
+            dashboard.models.Session.query.all(),
+            dashboard.models.RedcapConfig.query.all()
+        ]
+
+    @pytest.fixture
+    def det(self):
+        det_request = Mock()
+        # 'form' is the contents of a REDCap DET
+        # The below fields are all fields expected in a DET for
+        # version 11.1.21 and prior
+        det_request.form = {
+            "redcap_url": self.url,
+            "project_url": "{self.url}redcap_v{self.version}/index.php?" +
+                           "pid={self.pid}",
+            "project_id": self.pid,
+            "username": "redcap_user",
+            "record": self.record_id,
+            "redcap_event_name": self.event_name,
+            "instrument": self.instrument,
+            self.completed_field: self.completed_value
+        }
+        return det_request
+
+    @pytest.fixture
+    def records(self, dash_db):
+        # Create study STUDY with site ABC
+        study = dashboard.models.Study("STUDY")
+        dash_db.session.add(study)
+        study.update_site("ABC", code="STU01", create=True)
+
+        # Add a timepoint and session 01
+        timepoint = dashboard.models.Timepoint(self.session[:-3], "ABC")
+        study.add_timepoint(timepoint)
+        timepoint.add_session(1)
+
+        # Add a redcap_config entry
+        rc = dashboard.models.RedcapConfig(
+            self.pid,
+            self.instrument,
+            self.url
+        )
+        rc.date_field = self.date_field
+        rc.comment_field = self.comment_field
+        rc.session_id_field = self.session_field
+        rc.completed_field = self.completed_field
+        rc.completed_value = self.completed_value
+        rc.event_ids = self.event_ids
+        rc.token = self.token
+        dash_db.session.add(rc)
+        dash_db.session.commit()
+
+        return dash_db

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -108,7 +108,7 @@ class TestCreateFromRequest:
 
     def test_no_records_added_when_matching_redcap_config_not_found(
             self, mock_http, mock_monitor, det, records):
-        det.form["project_id"] = "0001"
+        det.form["project_id"] = 1111
         assert det.form["project_id"] != self.pid
 
         before_det = self.get_db_records()

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -207,6 +207,21 @@ class TestCreateFromRequest:
 
         assert db_record.event_id == self.event_ids[self.event_name]
 
+    def test_doesnt_fail_if_config_event_ids_not_set(
+            self, mock_http, mock_monitor, det, records):
+        mock_http.return_value = self.mock_redcap_export()
+
+        # Delete the event_ids from config
+        rc = dashboard.models.RedcapConfig.query.get(1)
+        rc.event_ids = None
+        dashboard.models.db.session.add(rc)
+        dashboard.models.db.session.commit()
+
+        assert not rc.event_ids
+        rc_utils.create_from_request(det)
+        record = dashboard.models.RedcapRecord.query.get(1)
+        assert record is not None
+
     def test_det_with_different_version_causes_redcap_config_version_update(
             self, mock_http, mock_monitor, det, records):
         mock_http.return_value = self.mock_redcap_export()

--- a/tests/test_redcap_bp_utils.py
+++ b/tests/test_redcap_bp_utils.py
@@ -207,7 +207,7 @@ class TestCreateFromRequest:
 
         assert db_record.event_id == self.event_ids[self.event_name]
 
-    def test_det_with_newer_version_causes_redcap_config_version_update(
+    def test_det_with_different_version_causes_redcap_config_version_update(
             self, mock_http, mock_monitor, det, records):
         mock_http.return_value = self.mock_redcap_export()
 
@@ -274,8 +274,8 @@ class TestCreateFromRequest:
         # version 11.1.21 and prior
         det_request.form = {
             "redcap_url": self.url,
-            "project_url": "{self.url}redcap_v{self.version}/index.php?" +
-                           "pid={self.pid}",
+            "project_url": f"{self.url}redcap_v{self.version}/index.php?" +
+                           f"pid={self.pid}",
             "project_id": self.pid,
             "username": "redcap_user",
             "record": self.record_id,


### PR DESCRIPTION
@josephmje noticed that the event IDs werent being set on redcap records in the database when the dashboard created them. This pull request addresses this issue.

- Add a column on RedcapConfig to store the event name -> event ID mappings 98c0d5179a6896c9789cc968cedfe88555d14278
- Add a migration script to update the database 7a11d629efe86004dfd1974226c3b3b7b1a42649
- Allow parse_config.py to update the event_ids column from the config files 01c97aef1f44ac21de2894a7bc76bd71f24b144c
- Add tests for `dashboard.blueprints.redcap.utils.create_from_request` to describe correct behavior for the function 912556cf6c44ee125df59364ad734670a2411bd6, b6b0641329ac857b573073fa3b06232b06e3e1f3, 8b08ae0a977e78bf4349b9e820d14e3427ec23e8
- Push the event ID for the received event name with the rest of the redcap record update 8b74be5c1a22e7a517a30b59ea9f4256bbd21cf2
-  Fix an unrelated bug where redcap version updates were causing "can't set attribute" errors a314acbd84fb34b71b3b196cc8d7ed0685a560ac
- Fix an unrelated bug where the redcap version wasn't being updated when data entry triggers were sent 9523ef5e5f2adcab4150f08ce8e66ecaf5cf9249
- Fix an exception caused when RedcapConfig doesnt have event_ids defined d063fa0cbb26e3e342460fc822c2cacdf13f0412