### PR TITLE
[ENH] Allow plugins to be installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ venv/
 *.log
 logs/
 dashboard/output.csv
+dashboard/static/niviz_rater

--- a/config/cluster.py
+++ b/config/cluster.py
@@ -19,5 +19,5 @@ SUBMIT_SCRIPTS = (
     os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         '../dashboard/queue_jobs'
-        )
     )
+)

--- a/config/database.py
+++ b/config/database.py
@@ -7,7 +7,7 @@ user = os.environ.get('POSTGRES_USER')
 
 # Password to connect with. Can be None if no password set or using identd or
 # other passwordless authentication method
-password = os.environ.get('POSTGRES_PASS')
+password = os.environ.get('POSTGRES_PASS', '')
 
 # Server to connect to. If unset, will attempt to find database locally
 server = os.environ.get('POSTGRES_SRVR') or 'localhost'

--- a/config/database.py
+++ b/config/database.py
@@ -15,20 +15,14 @@ server = os.environ.get('POSTGRES_SRVR') or 'localhost'
 # Name of database to connect to
 db_name = os.environ.get('POSTGRES_DATABASE') or 'dashboard'
 
-SQLALCHEMY_DATABASE_URI = 'postgresql://{user}:{pwd}@{srvr}/{db}'.format(
-    user=user,
-    pwd=password,
-    srvr=server,
-    db=db_name)
+DATABASE_ROOT_URI = f'postgresql://{user}:{password}@{server}'
+
+SQLALCHEMY_DATABASE_URI = f'{DATABASE_ROOT_URI}/{db_name}'
 
 # Configure the test database to use for unit tests
 test_db_name = os.environ.get('POSTGRES_TEST_DATABASE') or 'test_dashboard'
 
-SQLALCHEMY_TEST_DATABASE_URI = 'postgresql://{user}:{pwd}@{srvr}/{db}'.format(
-    user=user,
-    pwd=password,
-    srvr=server,
-    db=test_db_name)
+SQLALCHEMY_TEST_DATABASE_URI = f'{DATABASE_ROOT_URI}/{test_db_name}'
 
 # Timezone offset used for timezone aware timestamps. Default is Eastern time
 # Used by psycopg2.tz.FixedOffsetTimezone in the models
@@ -36,3 +30,5 @@ TZ_OFFSET = os.environ.get('TIMEZONE') or -240
 
 # Not needed and uses more memory. Just disable it.
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+SQLALCHEMY_BINDS = {}

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -111,7 +111,9 @@ def load_blueprints(app):
     A blueprint must be in the dashboard's blueprint folder and must
     implement the 'register_bp' function to be loaded by this function.
     """
-    bp_dir = "dashboard/blueprints"
+    bp_dir = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "blueprints")
     blueprints = [
         x for x in os.listdir(bp_dir)
         if os.path.isdir(os.path.join(bp_dir, x)) and

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -116,8 +116,8 @@ def load_blueprints(app):
         "blueprints")
     blueprints = [
         x for x in os.listdir(bp_dir)
-        if os.path.isdir(os.path.join(bp_dir, x)) and
-            x != "__pycache__"]
+        if (os.path.isdir(os.path.join(bp_dir, x)) and
+            x != "__pycache__")]
 
     for item in blueprints:
         bp = __import__("dashboard.blueprints." + str(item),

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -105,6 +105,29 @@ def setup_devel_ext(app):
     return toolbar
 
 
+def load_blueprints(app):
+    """Register all blueprints for the app.
+
+    A blueprint must be in the dashboard's blueprint folder and must
+    implement the 'register_bp' function to be loaded by this function.
+    """
+    bp_dir = "dashboard/blueprints"
+    blueprints = [
+        x for x in os.listdir(bp_dir)
+        if os.path.isdir(os.path.join(bp_dir, x)) and
+            x != "__pycache__"]
+
+    for item in blueprints:
+        bp = __import__("dashboard.blueprints." + str(item),
+                        fromlist=["register_bp"])
+        try:
+            app = bp.register_bp(app)
+        except AttributeError:
+            app.logger.error(
+                f"Ignoring blueprint {item}, 'register_bp' undefined.")
+    return app
+
+
 def create_app(config=None):
     """Generate an application instance from the given configuration.
 
@@ -133,21 +156,7 @@ def create_app(config=None):
 
     app.url_map.converters['regex'] = RegexConverter
 
-    from dashboard.blueprints.main import main_bp
-    from dashboard.blueprints.users import user_bp
-    from dashboard.blueprints.auth import auth_bp
-    from dashboard.blueprints.timepoints import time_bp
-    from dashboard.blueprints.scans import scan_bp
-    from dashboard.blueprints.redcap import rcap_bp
-    from dashboard.blueprints.handlers import handler_bp
-
-    app.register_blueprint(main_bp)
-    app.register_blueprint(user_bp)
-    app.register_blueprint(auth_bp)
-    app.register_blueprint(time_bp)
-    app.register_blueprint(rcap_bp)
-    app.register_blueprint(scan_bp)
-    app.register_blueprint(handler_bp)
+    load_blueprints(app)
 
     if app.debug and app.env == 'development':
         # Never run this on a production server!

--- a/dashboard/blueprints/auth/__init__.py
+++ b/dashboard/blueprints/auth/__init__.py
@@ -2,4 +2,10 @@ from flask import Blueprint
 
 auth_bp = Blueprint('auth', __name__)
 
+
+def register_bp(app):
+    app.register_blueprint(auth_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/handlers/__init__.py
+++ b/dashboard/blueprints/handlers/__init__.py
@@ -2,4 +2,10 @@ from flask import Blueprint
 
 handler_bp = Blueprint('handlers', __name__, template_folder='templates')
 
+
+def register_bp(app):
+    app.register_blueprint(handler_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/main/__init__.py
+++ b/dashboard/blueprints/main/__init__.py
@@ -2,4 +2,10 @@ from flask import Blueprint
 
 main_bp = Blueprint('main', __name__)
 
+
+def register_bp(app):
+    app.register_blueprint(main_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/main/views.py
+++ b/dashboard/blueprints/main/views.py
@@ -18,7 +18,7 @@ from ...queries import (query_metric_values_byid, query_metric_types,
 from ...models import Study, Site, Timepoint, Analysis
 from ...forms import (SelectMetricsForm, StudyOverviewForm, AnalysisForm)
 from ...utils import get_timepoint
-from ...datman_utils import get_study_path
+import dashboard.datman_utils
 
 logger = logging.getLogger(__name__)
 
@@ -433,7 +433,8 @@ def static_qc_page(study_id,
                    image=None,
                    tech_notes_path=None):
     if tech_notes_path:
-        resources = get_study_path(study_id, 'resources')
+        resources = dashboard.datman_utils.get_study_path(
+            study_id, 'resources')
         return send_from_directory(resources, tech_notes_path)
     timepoint = get_timepoint(study_id, timepoint_id, current_user)
     if image:

--- a/dashboard/blueprints/main/views.py
+++ b/dashboard/blueprints/main/views.py
@@ -426,7 +426,7 @@ def analysis(analysis_id=None):
 @main.route('/study/<string:study_id>/data/RESOURCES/<path:tech_notes_path>')
 @main.route('/study/<string:study_id>/qc/<string:timepoint_id>/index.html')
 @main.route('/study/<string:study_id>/qc/<string:timepoint_id>'
-           '/<regex(".*\.png"):image>')  # noqa: W605
+            '/<regex(".*\.png"):image>')  # noqa: W605
 @login_required
 def static_qc_page(study_id,
                    timepoint_id=None,

--- a/dashboard/blueprints/redcap/__init__.py
+++ b/dashboard/blueprints/redcap/__init__.py
@@ -2,4 +2,10 @@ from flask import Blueprint
 
 rcap_bp = Blueprint('redcap', __name__)
 
+
+def register_bp(app):
+    app.register_blueprint(rcap_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/redcap/utils.py
+++ b/dashboard/blueprints/redcap/utils.py
@@ -102,9 +102,8 @@ def create_from_request(request):
             server_record[cfg.user_id_field] if cfg.user_id_field else None
         )
     except KeyError:
-        raise RedcapException('Redcap record {} from server {} missing a '
-                              'required field. Found keys: {}'.format(
-                                  record, list(server_record.keys())))
+        raise RedcapException(f'Redcap record {record} missing required field.'
+                              f' Found keys: {list(server_record.keys())}')
 
     try:
         session = set_session(session_name)

--- a/dashboard/blueprints/redcap/views.py
+++ b/dashboard/blueprints/redcap/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import (render_template, redirect, request)
+from flask import (redirect, request)
 from flask_login import login_required
 
 from . import rcap_bp

--- a/dashboard/blueprints/scans/__init__.py
+++ b/dashboard/blueprints/scans/__init__.py
@@ -6,4 +6,10 @@ scan_bp = Blueprint(
     template_folder='templates',
     url_prefix='/study/<string:study_id>/scan/<int:scan_id>')
 
+
+def register_bp(app):
+    app.register_blueprint(scan_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/timepoints/__init__.py
+++ b/dashboard/blueprints/timepoints/__init__.py
@@ -6,4 +6,10 @@ time_bp = Blueprint(
     template_folder='templates',
     url_prefix='/study/<string:study_id>/timepoint/<string:timepoint_id>')
 
+
+def register_bp(app):
+    app.register_blueprint(time_bp)
+    return app
+
+
 from . import views

--- a/dashboard/blueprints/users/__init__.py
+++ b/dashboard/blueprints/users/__init__.py
@@ -6,4 +6,10 @@ user_bp = Blueprint(
     template_folder='templates',
     url_prefix='/user')
 
+
+def register_bp(app):
+    app.register_blueprint(user_bp)
+    return app
+
+
 from . import views

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -492,6 +492,7 @@ class Study(TableMixin, db.Model):
         collection_class=lambda: utils.DictListCollection('site'),
         viewonly=True,
     )
+    _pipelines = db.relationship('StudyPipeline', cascade='all, delete')
 
     def __init__(self,
                  study_id,
@@ -1011,6 +1012,21 @@ class Study(TableMixin, db.Model):
                     # Clean up tags not used by any other study
                     expected_scan.scantype.delete()
         super().delete()
+
+    def get_pipelines(self, scope=None):
+        if scope:
+            return [item for item in self._pipelines if item.scope == scope]
+        return self._pipelines
+
+    def add_pipeline(self, pipeline_key, view, name, scope):
+        record = StudyPipeline.query.get((self.id, pipeline_key))
+        if not record:
+            record = StudyPipeline(study_id=self.id, pipeline_id=pipeline_key)
+        record.view = view
+        record.name = name
+        record.scope = scope
+        record.save()
+        return record
 
     def __repr__(self):
         return "<Study {}>".format(self.id)
@@ -2330,6 +2346,39 @@ class StudySite(TableMixin, db.Model):
 
     def __repr__(self):
         return "<StudySite {} - {}>".format(self.study_id, self.site_id)
+
+
+class StudyPipeline(TableMixin, db.Model):
+    """Define QC pipelines enabled for a study.
+    """
+    study_id = db.Column('study',
+                         db.String(32),
+                         db.ForeignKey('studies.id'),
+                         primary_key=True)
+    pipeline_id = db.Column('pipeline_key',
+                            db.String,
+                            primary_key=True)
+    view = db.Column('view',
+                     db.String,
+                     nullable=False)
+    name = db.Column('name',
+                     db.String,
+                     nullable=False)
+    scope = db.Column('scope',
+                      db.ForeignKey('pipeline_scope.scope'),
+                      nullable=False)
+
+    __table_args__ = (UniqueConstraint(study_id, pipeline_id), )
+
+    def __repr__(self):
+        return f'<StudyPipeline {self.study_id} - {self.pipeline_id}>'
+
+
+class PipelineScope(db.Model):
+    scope = db.Column('scope', db.String(32), primary_key=True)
+
+    def __repr__(self):
+        return f'<PipelineScope {self.scope}>'
 
 
 class AltStudyCode(db.Model):

--- a/dashboard/queue.py
+++ b/dashboard/queue.py
@@ -8,6 +8,7 @@ from flask import current_app
 
 logger = logging.getLogger(__name__)
 
+
 def submit_job(script, input_args=None):
     """Attempt to submit a job to the configured computing cluster.
 

--- a/dashboard/templates/study.html
+++ b/dashboard/templates/study.html
@@ -80,7 +80,7 @@ Most of the html in the divs is extracted into a snippet file and rendered
         </li>
         {% for item in study.get_pipelines('study') %}
           <li role="presentation">
-            <a href="{{ url_for(item.view, study=item.study_id, pipeline=item.pipeline_key) }}">
+            <a href="{{ url_for(item.view, study=item.study_id, pipeline=item.pipeline_id) }}">
               {{ item.name }}
             </a>
           </li>

--- a/dashboard/templates/study.html
+++ b/dashboard/templates/study.html
@@ -78,6 +78,13 @@ Most of the html in the divs is extracted into a snippet file and rendered
         <li role="presentation">
           <a data-toggle="tab" href="#sessions">Session List</a>
         </li>
+        {% for item in study.get_pipelines('study') %}
+          <li role="presentation">
+            <a href="{{ url_for(item.view, study=item.study_id, pipeline=item.pipeline_key) }}">
+              {{ item.name }}
+            </a>
+          </li>
+        {% endfor %}
       </ul>
     </div>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to QC Dashboard's documentation!
 
    installation
    configuration
+   plugins
    developer
    api/modules
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,0 +1,23 @@
+-------
+Plugins
+-------
+
+Installing Plugins
+------------------
+The dashboard's functionality can easily be extended with blueprints. Copy
+the blueprint you want to add into ```datman-dashboard/dashboard/blueprints`` 
+and restart uwsgi to complete installation. The blueprint itself should document 
+any new environment variables to set, python packages to install, or databases 
+to create.
+
+
+Creating a Plugin
+-----------------
+To create your own blueprint you should do the following:
+
+#. Define a `flask blueprint <https://flask.palletsprojects.com/en/2.1.x/blueprints/>`_
+#. Define a ``register_bp`` function that accepts an app object and, at a
+   minimum, calls ``app.register_blueprint(your_bp_here)``. This function 
+   is an ideal place to add any configuration your plugin needs to 
+   the ``app.config`` dictionary. It's also where you'd want to add any 
+   alternate databases to the ``app.config['SQLALCHEMY_BINDS']`` dictionary

--- a/migrations/versions/94813db21f13_.py
+++ b/migrations/versions/94813db21f13_.py
@@ -23,23 +23,23 @@ def upgrade():
         sa.PrimaryKeyConstraint('scope')
     )
 
-    conn = op.get_bind()
     op.bulk_insert(
         scope,
         [{'scope': item}
          for item in ['study', 'timepoint', 'scan']]
     )
 
-    op.create_table('study_pipeline',
-    sa.Column('study', sa.String(length=32), nullable=False),
-    sa.Column('pipeline_key', sa.String(), nullable=False),
-    sa.Column('view', sa.String(), nullable=False),
-    sa.Column('name', sa.String(), nullable=False),
-    sa.Column('scope', sa.String(length=32), nullable=False),
-    sa.ForeignKeyConstraint(['scope'], ['pipeline_scope.scope'], ),
-    sa.ForeignKeyConstraint(['study'], ['studies.id'], ),
-    sa.PrimaryKeyConstraint('study', 'pipeline_key'),
-    sa.UniqueConstraint('study', 'pipeline_key')
+    op.create_table(
+        'study_pipeline',
+        sa.Column('study', sa.String(length=32), nullable=False),
+        sa.Column('pipeline_key', sa.String(), nullable=False),
+        sa.Column('view', sa.String(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('scope', sa.String(length=32), nullable=False),
+        sa.ForeignKeyConstraint(['scope'], ['pipeline_scope.scope'], ),
+        sa.ForeignKeyConstraint(['study'], ['studies.id'], ),
+        sa.PrimaryKeyConstraint('study', 'pipeline_key'),
+        sa.UniqueConstraint('study', 'pipeline_key')
     )
 
 

--- a/migrations/versions/94813db21f13_.py
+++ b/migrations/versions/94813db21f13_.py
@@ -1,0 +1,48 @@
+"""Add tables for managing installed QC Pipelines.
+
+Revision ID: 94813db21f13
+Revises: b68a8193acad
+Create Date: 2022-06-01 22:17:51.632942
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '94813db21f13'
+down_revision = 'b68a8193acad'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    scope = op.create_table(
+        'pipeline_scope',
+        sa.Column('scope', sa.String(length=32), nullable=False),
+        sa.PrimaryKeyConstraint('scope')
+    )
+
+    conn = op.get_bind()
+    op.bulk_insert(
+        scope,
+        [{'scope': item}
+         for item in ['study', 'timepoint', 'scan']]
+    )
+
+    op.create_table('study_pipeline',
+    sa.Column('study', sa.String(length=32), nullable=False),
+    sa.Column('pipeline_key', sa.String(), nullable=False),
+    sa.Column('view', sa.String(), nullable=False),
+    sa.Column('name', sa.String(), nullable=False),
+    sa.Column('scope', sa.String(length=32), nullable=False),
+    sa.ForeignKeyConstraint(['scope'], ['pipeline_scope.scope'], ),
+    sa.ForeignKeyConstraint(['study'], ['studies.id'], ),
+    sa.PrimaryKeyConstraint('study', 'pipeline_key'),
+    sa.UniqueConstraint('study', 'pipeline_key')
+    )
+
+
+def downgrade():
+    op.drop_table('study_pipeline')
+    op.drop_table('pipeline_scope')


### PR DESCRIPTION
This pull request 

- Changes how blueprints are registered, so new ones can be added without modifications to `dashboard/__init__.py`
- Adds StudyPipeline and Scope tables to track which QC pipelines are active for each study and how to access QC views
- Modifies the study view html to display links to any QC pipelines configured for the study
- Adds documentation on creating + installing plugins for the dashboard
- Fixes some PEP8 issues
