### PR TITLE
[ENH] Add nightly run logs to study home page

### DIFF
--- a/config/misc.py
+++ b/config/misc.py
@@ -31,10 +31,10 @@ REDCAP_TOKEN = os.environ.get('REDCAP_TOKEN')
 RUN_LOG_DIR = os.environ.get('DATMAN_RUN_LOGS', '')
 
 # The regex to use when parsing the run log to tell if nightly run is complete
-RUN_COMPLETE_REGEX = os.environ.get('DATMAN_RUN_LOGS_REGEX', ': Done.')
+RUN_COMPLETE_REGEX = os.environ.get('DATMAN_RUN_LOGS_DONE', ': Done.')
 
 # The regex to use when parsing the run log to detect errors
-RUN_ERROR_REGEX = os.environ.get('DATMAN_RUN_LOGS_ERROR_REGEX', '- ERROR -')
+RUN_ERROR_REGEX = os.environ.get('DATMAN_RUN_LOGS_ERROR', '- ERROR -')
 
 # Metrics to display.
 # NOTE: The code that uses this is currently broken and might be scrapped

--- a/config/misc.py
+++ b/config/misc.py
@@ -27,6 +27,15 @@ GITHUB_PUBLIC = read_boolean('GITHUB_ISSUES_PUBLIC', default=True)
 # The REDCap token to use when retrieving records after a data entry trigger
 REDCAP_TOKEN = os.environ.get('REDCAP_TOKEN')
 
+# The directory to read nightly run logs from, if any
+RUN_LOG_DIR = os.environ.get('DATMAN_RUN_LOGS', '')
+
+# The regex to use when parsing the run log to tell if nightly run is complete
+RUN_COMPLETE_REGEX = os.environ.get('DATMAN_RUN_LOGS_REGEX', ': Done.')
+
+# The regex to use when parsing the run log to detect errors
+RUN_ERROR_REGEX = os.environ.get('DATMAN_RUN_LOGS_ERROR_REGEX', '- ERROR -')
+
 # Metrics to display.
 # NOTE: The code that uses this is currently broken and might be scrapped
 # entirely

--- a/containers/dashboard.env
+++ b/containers/dashboard.env
@@ -86,6 +86,13 @@ POSTGRES_DATABASE=dashboard
 # DASHBOARD_URL=
 
 
+# Run Log Reporting
+# -----------------
+# DATMAN_RUN_LOGS=
+# DATMAN_RUN_LOGS_DONE=": Done."
+# DATMAN_RUN_LOGS_ERROR="- ERROR -"
+
+
 # XNAT
 # ----
 # DASH_ENABLE_XNAT=False

--- a/dashboard/blueprints/main/utils.py
+++ b/dashboard/blueprints/main/utils.py
@@ -1,0 +1,32 @@
+import os
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+def get_run_log(log_dir, study, done_regex, error_regex):
+    log_file = os.path.join(log_dir, f"{study}_latest.log")
+    output = {}
+    output["contents"] = read_log(log_file)
+    output["header"] = make_header_msg(
+        output["contents"], done_regex, error_regex)
+    return output
+
+
+def read_log(log_file):
+    try:
+        with open(log_file, "r") as contents:
+            result = contents.readlines()
+    except Exception as e:
+        logger.error(f"Failed to read run log file {log_file}. {e}")
+        return ""
+    result = [line.replace("\n", "<br>") for line in result]
+    return "<br>".join(result)
+
+
+def make_header_msg(log_contents, done_regex, error_regex):
+    if not re.search(done_regex, log_contents):
+        return "Running..."
+    error_count = len(re.findall(error_regex, log_contents))
+    return f"{error_count} errors reported"

--- a/dashboard/blueprints/main/utils.py
+++ b/dashboard/blueprints/main/utils.py
@@ -1,4 +1,5 @@
 import os
+import html
 import logging
 import re
 
@@ -24,7 +25,7 @@ def read_log(log_file):
     except Exception as e:
         logger.error(f"Failed to read run log file {log_file}. {e}")
         return ""
-    result = [line.replace("\n", "<br>") for line in result]
+    result = [html.escape(line).replace("\n", "<br>") for line in result]
     return "<br>".join(result)
 
 
@@ -32,4 +33,6 @@ def make_header_msg(log_contents, done_regex, error_regex):
     if not re.search(done_regex, log_contents):
         return "Running..."
     error_count = len(re.findall(error_regex, log_contents))
+    if error_count == 1:
+        return "1 error reported"
     return f"{error_count} errors reported"

--- a/dashboard/blueprints/main/utils.py
+++ b/dashboard/blueprints/main/utils.py
@@ -6,6 +6,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_run_log(log_dir, study, done_regex, error_regex):
+    if not log_dir:
+        return {"contents": "", "header": ""}
+
     log_file = os.path.join(log_dir, f"{study}_latest.log")
     output = {}
     output["contents"] = read_log(log_file)

--- a/dashboard/blueprints/main/views.py
+++ b/dashboard/blueprints/main/views.py
@@ -12,6 +12,7 @@ from flask_login import current_user, login_required
 
 from dashboard import db
 from . import main_bp as main
+from .utils import get_run_log
 from ...queries import (query_metric_values_byid, query_metric_types,
                         query_metric_values_byname, find_subjects,
                         find_sessions, find_scans)
@@ -146,10 +147,17 @@ def study(study_id=None, active_tab=None):
     form.readme_txt.data = study.read_me
     form.study_id.data = study_id
 
+    nightly_log = get_run_log(
+        current_app.config['RUN_LOG_DIR'],
+        study_id,
+        current_app.config['RUN_COMPLETE_REGEX'],
+        current_app.config['RUN_ERROR_REGEX'])
+
     return render_template('study.html',
                            study=study,
                            form=form,
                            active_tab=active_tab,
+                           nightly_log=nightly_log,
                            display_metrics=display_metrics)
 
 

--- a/dashboard/static/css/qc_dashboard.css
+++ b/dashboard/static/css/qc_dashboard.css
@@ -143,14 +143,14 @@ thead {
 /**********************************************
 * Study page styling
 ***********************************************/
-#qc-panel {
-  width: 60%;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 #qclist {
   /* Make the qc panel body scrollable if the list is too long */
+  height: auto;
+  max-height: 300px;
+  overflow-x: hidden;
+}
+
+#run-log {
   height: auto;
   max-height: 300px;
   overflow-x: hidden;

--- a/dashboard/templates/study.html
+++ b/dashboard/templates/study.html
@@ -33,27 +33,56 @@ Most of the html in the divs is extracted into a snippet file and rendered
         </p>
     </div>
 
-    <!-- The 'Outstanding QC' panel -->
-    {% set pending_qc = study.outstanding_issues() %}
-    {% if pending_qc|count %}
-      <div id="qc-panel" class="panel panel-danger">
-        <div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#qclist">
-          <h3 class="panel-title chevron-toggle">Outstanding QC</h3>
-        </div>
-        <div class="panel-body collapse in" id="qclist">
-          <table class="table table-striped table-hover table-condensed">
-            {% for timepoint in pending_qc | sort %}
-              <tr class="clickable-row" data-href="{{ url_for('timepoints.timepoint', study_id=study.id, timepoint_id=timepoint) }}">
-                <td class="col-xs-2">{{ timepoint }}</td>
-                  {% for column in pending_qc[timepoint] %}
-                    {{ column|safe }}
-                  {% endfor %}
-              </tr>
-            {% endfor %}
-          </table>
-        </div>
+    <div class="row">
+      {% set pending_qc = study.outstanding_issues() %}
+      {% if pending_qc|count and nightly_log["contents"] != "" %}
+        {% set qc_width = 6 %}
+        {% set log_width = 6 %}
+      {% elif pending_qc|count %}
+        {% set qc_width = 12 %}
+        {% set log_width = 0 %}
+      {% else %}
+        {% set qc_width = 0 %}
+        {% set log_width = 12%}
+      {% endif %}
+
+      <!-- The 'Outstanding QC' panel -->
+      <div class="col-xs-{{ qc_width }}">
+        {% if pending_qc|count %}
+          <div class="panel panel-danger">
+            <div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#qclist">
+              <h3 class="panel-title chevron-toggle">Outstanding QC</h3>
+            </div>
+            <div class="panel-body collapse in" id="qclist">
+              <table class="table table-striped table-hover table-condensed">
+                {% for timepoint in pending_qc | sort %}
+                  <tr class="clickable-row" data-href="{{ url_for('timepoints.timepoint', study_id=study.id, timepoint_id=timepoint) }}">
+                    <td class="col-xs-2">{{ timepoint }}</td>
+                      {% for column in pending_qc[timepoint] %}
+                        {{ column|safe }}
+                      {% endfor %}
+                  </tr>
+                {% endfor %}
+              </table>
+            </div>
+          </div>
+        {% endif %}
       </div>
-    {% endif %}
+
+      <!-- The run log display panel -->
+      <div class="col-xs-{{ log_width }}">
+        {% if nightly_log["contents"] != "" %}
+          <div class="panel panel-info" title="The Most Recent Nightly Run Log" width="100%">
+            <div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#run-log">
+              <h3 class="panel-title chevron-toggle">Nightly Run Log ({{ nightly_log["header"] }})</h3>
+            </div>
+            <div class="panel-body collapse in" id="run-log">
+              <div>{{ nightly_log["contents"]|safe }}</div>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
 
     <!-- The tab menu -->
     <div role="navigation">

--- a/dashboard/templates/study.html
+++ b/dashboard/templates/study.html
@@ -36,18 +36,18 @@ Most of the html in the divs is extracted into a snippet file and rendered
     <div class="row">
       {% set pending_qc = study.outstanding_issues() %}
       {% if pending_qc|count and nightly_log["contents"] != "" %}
-        {% set qc_width = 6 %}
-        {% set log_width = 6 %}
+        {% set qc_classes = "col-xs-6" %}
+        {% set log_classes = "col-xs-6" %}
       {% elif pending_qc|count %}
-        {% set qc_width = 12 %}
-        {% set log_width = 0 %}
+        {% set qc_classes = "col-xs-6 col-xs-offset-3" %}
+        {% set log_classes = "col-xs-0" %}
       {% else %}
-        {% set qc_width = 0 %}
-        {% set log_width = 12%}
+        {% set qc_classes = "col-xs-0" %}
+        {% set log_classes = "col-xs-6 col-xs-offset-3" %}
       {% endif %}
 
       <!-- The 'Outstanding QC' panel -->
-      <div class="col-xs-{{ qc_width }}">
+      <div class="{{ qc_classes }}">
         {% if pending_qc|count %}
           <div class="panel panel-danger">
             <div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#qclist">
@@ -70,7 +70,7 @@ Most of the html in the divs is extracted into a snippet file and rendered
       </div>
 
       <!-- The run log display panel -->
-      <div class="col-xs-{{ log_width }}">
+      <div class="{{ log_classes }}">
         {% if nightly_log["contents"] != "" %}
           <div class="panel panel-info" title="The Most Recent Nightly Run Log" width="100%">
             <div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#run-log">

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -374,6 +374,37 @@ Configuration for the dashboard's job scheduler.
   * Description: The URL to send scheduler jobs to. This setting is needed 
     only by 'client' instances of the dashboard.
     
+Run Log Reporting
+*****************
+Configures whether to display nightly pipeline run logs. If nightly scripts
+are run for a study's data, the base directory where logs are stored can be
+provided to ensure the most recent run log is displayed on the study's landing
+page. Note that the most recent log for each study should be named
+``STUDY_latest.log``, where STUDY is the name datman recognizes the study by.
+
+Required
+^^^^^^^^
+
+Optional
+^^^^^^^^
+* **DATMAN_RUN_LOGS**
+
+  * Description: The directory to read recent nightly run logs from. If
+    left unset run log reporting will be turned off. Log files in this
+    directory should be named ``STUDY_latest.log``, where study is
+    the datman nickname.
+* **DATMAN_RUN_LOGS_DONE**
+
+  * Description: The pattern to search for in the log to identify whether
+    or not the nightly run has finished.
+  * Default value: ``: Done.``
+* **DATMAN_RUN_LOGS_ERROR**
+
+  * Description: The pattern to use to identify log lines that contain errors.
+    Used to construct a count of the number of errors in the log, which is
+    then displayed in the summary line of the log display.
+  * Default value: ``- ERROR -``
+
 XNAT
 ****
 Enable or disable the XNAT integration. Note that if you enable XNAT 

--- a/tests/test_main_bp_utils.py
+++ b/tests/test_main_bp_utils.py
@@ -1,0 +1,81 @@
+from mock import patch, Mock
+
+import dashboard.blueprints.main.utils as utils
+
+
+class TestMakeHeaderMsg:
+
+    done_regex = ": Done."
+    error_regex = "- ERROR -"
+
+    def test_detects_if_nightly_run_unfinished(self):
+        log_contents = """
+        Sat 04 Jun 2022 01:08:41 AM EDT: Running pipelines for study: STUDY1
+        Sat 04 Jun 2022 01:09:04 AM EDT: Get new scans...
+        """
+        result = utils.make_header_msg(
+            log_contents,
+            self.done_regex,
+            self.error_regex
+        )
+        assert result == "Running..."
+
+    def test_counts_errors_in_logs_if_finished(self):
+        log_contents = """
+        Sat 04 Jun 2022 01:08:41 AM EDT: Running pipelines for study: STUDY1
+        Sat 04 Jun 2022 01:09:04 AM EDT: Get new scans...
+        2022-06-04 01:46:16,366 - dm_link.py - OPT - ERROR - Scanid not found for archive /archive/data/STUDY1/data/zips/STUDY1_abcd.zip
+        2022-06-04 03:40:18,945 - script1.py - STUDY1 - ERROR - Invalid session
+        Sat 04 Jun 2022 03:41:40 AM EDT: Done.
+        """  # NOQA: E501
+        result = utils.make_header_msg(
+            log_contents,
+            self.done_regex,
+            self.error_regex
+        )
+        assert result == "2 errors reported"
+
+    def test_correct_grammar_when_one_error_exists(self):
+        log_contents = """
+        Sat 04 Jun 2022 01:08:41 AM EDT: Running pipelines for study: STUDY1
+        Sat 04 Jun 2022 01:09:04 AM EDT: Get new scans...
+        2022-06-04 03:40:18,945 - script1.py - STUDY1 - ERROR - Invalid session
+        Sat 04 Jun 2022 03:41:40 AM EDT: Done.
+        """
+        result = utils.make_header_msg(
+            log_contents,
+            self.done_regex,
+            self.error_regex
+        )
+        assert result == "1 error reported"
+
+
+class TestReadLog:
+
+    @patch("builtins.open")
+    def test_escapes_html_present_in_logfile(self, mock_open):
+        mock_fh = Mock()
+        mock_fh.readlines.return_value = [
+            "<textarea> Sometext goes here </textarea>\n",
+            "<h3>A header</h3>\n",
+            "Sat 04 Jun 2022 01:08:41 AM EDT: Normal log line\n"
+        ]
+        mock_open.return_value.__enter__.return_value = mock_fh
+        result = utils.read_log("/tmp/some_fake_file.txt")
+
+        expected = "&lt;textarea&gt; Sometext goes here &lt;/textarea&gt;" + \
+                   "<br><br>&lt;h3&gt;A header&lt;/h3&gt;<br><br>Sat 04 " + \
+                   "Jun 2022 01:08:41 AM EDT: Normal log line<br>"
+        assert result == expected
+
+
+class TestGetRunLog:
+
+    @patch("dashboard.blueprints.main.utils.read_log")
+    def test_doesnt_try_to_read_file_when_log_dir_not_set(self, mock_read):
+        utils.get_run_log("", "STUDY1", ": Done.", "- ERROR -")
+        assert mock_read.call_count == 0
+
+    def test_returns_correctly_formatted_dict_when_log_dir_not_set(self):
+        result = utils.get_run_log("", "STUDY1", ": Done.", "- ERROR -")
+        assert result == {"contents": "", "header": ""}


### PR DESCRIPTION
This pull request will add a display box for studies with a recent nightly run log. The box containers a 'header' line to indicate whether the nightly pipeline is still running or, if finished for the night, a count of the errors reported.
![run_log1](https://user-images.githubusercontent.com/10541496/172463351-1ae8d173-09d6-482a-a3a9-053efe78c30d.png)
![run_log2](https://user-images.githubusercontent.com/10541496/172463358-c1798fa0-ad03-4149-8cc6-ae610dff40ce.png)

