### PR TITLE
[ENH] Allow a non-standard postgres port to be used

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -15,7 +15,11 @@ server = os.environ.get('POSTGRES_SRVR') or 'localhost'
 # Name of database to connect to
 db_name = os.environ.get('POSTGRES_DATABASE') or 'dashboard'
 
-DATABASE_ROOT_URI = f'postgresql://{user}:{password}@{server}'
+# Port the database (or connection pooler) is listening on
+port = (':' + os.environ.get('POSTGRES_PORT')
+        if os.environ.get('POSTGRES_PORT') else '')
+
+DATABASE_ROOT_URI = f'postgresql://{user}:{password}@{server}{port}'
 
 SQLALCHEMY_DATABASE_URI = f'{DATABASE_ROOT_URI}/{db_name}'
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -78,6 +78,10 @@ Optional
 
   * Description: The username to use when connecting to the database.
   * Default value: The username that the dashboard runs under.
+* **POSTGRES_PORT**
+
+  * Description: The port to use when connecting to the database.
+  * Default value: ``5432``
 * **TIMEZONE**
   
   * Description: The time zone to use when storing timestamps. Note that this 


### PR DESCRIPTION
This allows the dashboard to connect to a non-default postgres port. We'll use this to connect to the connection pooler to reduce our connection load issues :) 