### PR TITLE
[ENH] Add page to search through and download QC records

### DIFF
--- a/dashboard/blueprints/qc_search/__init__.py
+++ b/dashboard/blueprints/qc_search/__init__.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 
 checklist_bp = Blueprint(
-    'qc_search',
+    "qc_search",
     __name__,
     template_folder="templates",
     static_folder="static",

--- a/dashboard/blueprints/qc_search/__init__.py
+++ b/dashboard/blueprints/qc_search/__init__.py
@@ -1,0 +1,16 @@
+from flask import Blueprint
+
+checklist_bp = Blueprint(
+    'qc_search',
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    url_prefix="/qc-reviews")
+
+
+def register_bp(app):
+    app.register_blueprint(checklist_bp)
+    return app
+
+
+from . import views

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -3,24 +3,20 @@ from wtforms import SubmitField, BooleanField, SelectMultipleField, TextField
 from wtforms.csrf.core import CSRFTokenField
 
 class QcSearchForm(FlaskForm):
-    approved = BooleanField("Include Approved Scans", default=True,
-                            render_kw={"class": "qc-search-bool"})
-    blacklisted = BooleanField("Include Blacklisted Scans", default=True,
-                               render_kw={"class": "qc-search-bool"})
-    flagged = BooleanField("Include Flagged Scans", default=True,
-                           render_kw={"class": "qc-search-bool"})
-    include_phantoms = BooleanField("Include Phantoms", default=False,
-                                    render_kw={"class": "qc-search-bool"})
-    include_new = BooleanField("Include Scans Without Review", default=False,
-                               render_kw={"class": "qc-search-bool"})
-    study = SelectMultipleField("Select all studies to search",
+    approved = BooleanField("Include Approved Scans", default=True)
+    blacklisted = BooleanField("Include Blacklisted Scans", default=True)
+    flagged = BooleanField("Include Flagged Scans", default=True)
+    include_phantoms = BooleanField("Include Phantoms", default=False)
+    include_new = BooleanField("Include Scans Without Review", default=False)
+    study = SelectMultipleField("Limit to selected studies",
                                 render_kw={"class": "qc-search-select"})
-    site = SelectMultipleField("Select all sites to search",
+    site = SelectMultipleField("Limit to selected sites",
                                render_kw={"class": "qc-search-select"})
-    tag = SelectMultipleField("Select all tags to search",
+    tag = SelectMultipleField("Limit to selected tags",
                               render_kw={"class": "qc-search-select"})
     comment = TextField(
-        "Enter a semi-colon delimited list of comments to search for",
+        "Limit to records containing select comments "
+        "(use semi-colons to separate multiple comments)",
         render_kw={"class": "qc-search-text"})
 
 

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -1,0 +1,25 @@
+from flask_wtf import FlaskForm
+from wtforms import SubmitField, BooleanField, SelectMultipleField, TextField
+
+class QcSearchForm(FlaskForm):
+    approved = BooleanField("Include Approved Scans", default=True,
+                            render_kw={"class": "qc-search-bool"})
+    blacklisted = BooleanField("Include Blacklisted Scans", default=True,
+                               render_kw={"class": "qc-search-bool"})
+    flagged = BooleanField("Include Flagged Scans", default=True,
+                           render_kw={"class": "qc-search-bool"})
+    include_phantoms = BooleanField("Include Phantoms", default=False,
+                                    render_kw={"class": "qc-search-bool"})
+    include_new = BooleanField("Include Scans Without Review", default=False,
+                               render_kw={"class": "qc-search-bool"})
+    study = SelectMultipleField("Select all studies to search",
+                                render_kw={"class": "qc-search-select"})
+    site = SelectMultipleField("Select all sites to search",
+                               render_kw={"class": "qc-search-select"})
+    tag = SelectMultipleField("Select all tags to search",
+                              render_kw={"class": "qc-search-select"})
+    comment = TextField(
+        "Enter a semi-colon delimited list of comments to search for",
+        render_kw={"class": "qc-search-text"})
+
+    submit = SubmitField("Search")

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -8,6 +8,7 @@ class QcSearchForm(FlaskForm):
     flagged = BooleanField("Include Flagged Scans", default=True)
     include_phantoms = BooleanField("Include Phantoms", default=False)
     include_new = BooleanField("Include Scans Without Review", default=False)
+    sort = BooleanField("Sort Results", default=False)
     study = SelectMultipleField("Limit to selected studies",
                                 render_kw={"class": "qc-search-select"})
     site = SelectMultipleField("Limit to selected sites",

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -23,8 +23,6 @@ class QcSearchForm(FlaskForm):
         "Enter a semi-colon delimited list of comments to search for",
         render_kw={"class": "qc-search-text"})
 
-    submit = SubmitField("Search")
-
 
 def get_form_contents(form):
     """Retrieve the contents of a form (excluding fields only WTForms needs).

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -1,5 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import SubmitField, BooleanField, SelectMultipleField, TextField
+from wtforms.csrf.core import CSRFTokenField
 
 class QcSearchForm(FlaskForm):
     approved = BooleanField("Include Approved Scans", default=True,
@@ -23,3 +24,22 @@ class QcSearchForm(FlaskForm):
         render_kw={"class": "qc-search-text"})
 
     submit = SubmitField("Search")
+
+
+def get_form_contents(form):
+    """Retrieve the contents of a form (excluding fields only WTForms needs).
+
+    Args:
+        form (wtforms.form.FormMeta): An instance of a WTForm (or FlaskWTForm).
+
+    Returns:
+        dict: A dictionary of all field names mapped to their value (excluding
+            any CSRFToken fields or submit fields).
+    """
+    contents = {}
+    for fname in form._fields:
+        field = form._fields[fname]
+        if isinstance(field, CSRFTokenField) or isinstance(field, SubmitField):
+            continue
+        contents[fname] = field.data
+    return contents

--- a/dashboard/blueprints/qc_search/forms.py
+++ b/dashboard/blueprints/qc_search/forms.py
@@ -39,5 +39,25 @@ def get_form_contents(form):
         field = form._fields[fname]
         if isinstance(field, CSRFTokenField) or isinstance(field, SubmitField):
             continue
-        contents[fname] = field.data
+
+        if fname == "comment":
+            contents[fname] = parse_comment(field.data)
+        else:
+            contents[fname] = field.data
+
     return contents
+
+
+def parse_comment(user_input):
+    # Strip quotation marks and white space and split by semi-colon
+    if not user_input:
+        return []
+
+    strip = ['"', "'"]
+    search_terms = []
+    for term in user_input.split(";"):
+        term = term.strip()
+        for item in strip:
+            term = term.lstrip(item).rstrip(item)
+        search_terms.append(term)
+    return search_terms

--- a/dashboard/blueprints/qc_search/static/qc-search.css
+++ b/dashboard/blueprints/qc_search/static/qc-search.css
@@ -1,0 +1,13 @@
+.qc-search-select {
+  width: 100%;
+  margin-top: 15px;
+  margin-bottom: 10px;
+}
+
+#qc-search-interface {
+  margin-top: 10px;
+}
+
+#qc-download {
+  margin-bottom: 5px;
+}

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -1,10 +1,10 @@
 /* Functions to implement the QC search form and display */
 
-$('.qc-search-submit').off().on('click', function(e) {
+$('#qc-search-form').submit(function(e) {
   e.preventDefault();
 
   function failFunc(response) {
-    console.log(response);
+    console.log("Failed to handle request");
   }
 
   $.ajaxSetup({
@@ -19,8 +19,9 @@ $('.qc-search-submit').off().on('click', function(e) {
   $.ajax({
     type: 'POST',
     url: searchUrl,
-    contentType: 'application/json',
+    data: $(this).serialize(),
     success: function() {console.log("Success!");},
     error: failFunc
   });
+
 });

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -1,6 +1,60 @@
 /* Functions to implement the QC search form and display */
 
-$('#qc-search-form').submit(function(e) {
+function parseValue(value) {
+  /* Convert 'nulls' to empty strings and perform any other formatting needed
+     for table values
+  */
+  if (value === null) {
+    return ""
+  }
+
+  return value
+}
+
+function displayRecords(records) {
+  var tableBody = $("#qc-search-results-table tbody")[0];
+
+  let body = "";
+  for (let i = 0; i < records.length; i += 1) {
+    body += `
+      <tr>
+        <td>${records[i]['name']}</td>
+        <td>${parseValue(records[i]['approved'])}</td>
+        <td>${parseValue(records[i]['comment'])}</td>
+      </tr>
+    `
+  }
+
+  tableBody.innerHTML = body;
+};
+
+function makeCsv() {
+  /* Construct a csv from the currently displayed search records */
+  var csv = [];
+  var rows = $("#qc-search-results-table tr");
+  for (var i = 0; i < rows.length; i += 1) {
+    var cols = rows[i].querySelectorAll('td,th');
+    var col = []
+    for (var j = 0; j < cols.length; j += 1) {
+      col.push(cols[j].innerHTML);
+    }
+    csv.push(col.join(","));
+  }
+  return csv.join("\n");
+};
+
+function downloadCsv() {
+  /* Download the search results as a csv */
+  var downloadBtn = $("#qc-download")[0];
+  var outFile = new Blob([makeCsv()], {type: "text/csv"});
+  var url = window.URL.createObjectURL(outFile);
+  downloadBtn.href = url;
+};
+
+$("#qc-download").on("click", downloadCsv);
+
+$("#qc-search-form").submit(function(e) {
+  /* Submit the search terms to the server and handle response. */
   e.preventDefault();
 
   function failFunc(response) {
@@ -20,8 +74,13 @@ $('#qc-search-form').submit(function(e) {
     type: 'POST',
     url: searchUrl,
     data: $(this).serialize(),
-    success: function() {console.log("Success!");},
+    success: displayRecords,
     error: failFunc
   });
 
+});
+
+$("#qc-search-reset").on("click", function() {
+  // Reset the form when the 'clear' button is clicked
+  $("#qc-search-form")[0].reset();
 });

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -2,7 +2,7 @@
 
 function parseValue(value) {
   /* Convert 'nulls' to empty strings and perform any other formatting needed
-     for table values
+     for table values.
   */
   if (value === null) {
     return ""
@@ -12,6 +12,7 @@ function parseValue(value) {
 }
 
 function displayRecords(records) {
+  /* Update the qc search results table with the given list of records. */
   let tableBody = $("#qc-search-results-table tbody")[0];
 
   let body = "";
@@ -67,7 +68,7 @@ function delLoadingStatus() {
 }
 
 function failedSearch(response) {
-  console.log("Firing off fail function");
+  /* Inform the user that the server failed to handle their search. */
   $("#qc-search-terms-display").prepend(
     '<div id="qc-search-fail" class="alert alert-danger" role="alert">' +
     'Failed to search database, please contact an admin.' +
@@ -107,6 +108,6 @@ $("#qc-search-form").submit(function(e) {
 });
 
 $("#qc-search-reset").on("click", function() {
-  // Reset the form when the 'clear' button is clicked
+  /* Reset the form when the 'clear' button is clicked. */
   $("#qc-search-form")[0].reset();
 });

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -87,11 +87,6 @@ $("#qc-search-form").submit(function(e) {
   /* Submit the search terms to the server and handle response. */
   e.preventDefault();
 
-  function failFunc(response) {
-    console.log("Failed to handle request");
-    delLoadingStatus();
-  }
-
   $.ajaxSetup({
     beforeSend: function(xhr, settings) {
       if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) &&

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -12,7 +12,7 @@ function parseValue(value) {
 }
 
 function displayRecords(records) {
-  var tableBody = $("#qc-search-results-table tbody")[0];
+  let tableBody = $("#qc-search-results-table tbody")[0];
 
   let body = "";
   for (let i = 0; i < records.length; i += 1) {
@@ -26,16 +26,17 @@ function displayRecords(records) {
   }
 
   tableBody.innerHTML = body;
+  delLoadingStatus();
 };
 
 function makeCsv() {
   /* Construct a csv from the currently displayed search records */
-  var csv = [];
-  var rows = $("#qc-search-results-table tr");
-  for (var i = 0; i < rows.length; i += 1) {
-    var cols = rows[i].querySelectorAll('td,th');
-    var col = []
-    for (var j = 0; j < cols.length; j += 1) {
+  let csv = [];
+  let rows = $("#qc-search-results-table tr");
+  for (let i = 0; i < rows.length; i += 1) {
+    let cols = rows[i].querySelectorAll('td,th');
+    let col = []
+    for (let j = 0; j < cols.length; j += 1) {
       col.push(cols[j].innerHTML);
     }
     csv.push(col.join(","));
@@ -45,13 +46,42 @@ function makeCsv() {
 
 function downloadCsv() {
   /* Download the search results as a csv */
-  var downloadBtn = $("#qc-download")[0];
-  var outFile = new Blob([makeCsv()], {type: "text/csv"});
-  var url = window.URL.createObjectURL(outFile);
+  let downloadBtn = $("#qc-download")[0];
+  let outFile = new Blob([makeCsv()], {type: "text/csv"});
+  let url = window.URL.createObjectURL(outFile);
   downloadBtn.href = url;
 };
 
+function addLoadingStatus() {
+  /* Update the search button text + disable button */
+  let btn = $("#qc-search-btn")[0];
+  btn.innerHTML = '<span class="fa-lg"><i class="fas fa-cog fa-spin"></i></span> Working';
+  btn.disabled = true;
+};
+
+function delLoadingStatus() {
+  /* Update the search button text + enable button */
+  let btn = $("#qc-search-btn")[0];
+  btn.innerHTML = '<span class="fas fa-search"></span> Search';
+  btn.disabled = false;
+}
+
+function failedSearch(response) {
+  console.log("Firing off fail function");
+  $("#qc-search-terms-display").prepend(
+    '<div id="qc-search-fail" class="alert alert-danger" role="alert">' +
+    'Failed to search database, please contact an admin.' +
+    '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
+    '</div>');
+  delLoadingStatus();
+}
+
 $("#qc-download").on("click", downloadCsv);
+
+$("#qc-search-btn").on("click", function() {
+  $("#qc-search-form").submit();
+  addLoadingStatus();
+});
 
 $("#qc-search-form").submit(function(e) {
   /* Submit the search terms to the server and handle response. */
@@ -59,6 +89,7 @@ $("#qc-search-form").submit(function(e) {
 
   function failFunc(response) {
     console.log("Failed to handle request");
+    delLoadingStatus();
   }
 
   $.ajaxSetup({
@@ -75,7 +106,7 @@ $("#qc-search-form").submit(function(e) {
     url: searchUrl,
     data: $(this).serialize(),
     success: displayRecords,
-    error: failFunc
+    error: failedSearch
   });
 
 });

--- a/dashboard/blueprints/qc_search/static/qc-search.js
+++ b/dashboard/blueprints/qc_search/static/qc-search.js
@@ -1,0 +1,26 @@
+/* Functions to implement the QC search form and display */
+
+$('.qc-search-submit').off().on('click', function(e) {
+  e.preventDefault();
+
+  function failFunc(response) {
+    console.log(response);
+  }
+
+  $.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+      if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) &&
+          !this.crossDomain) {
+          xhr.setRequestHeader('X-CSRFToken', csrfToken)
+      }
+    }
+  });
+
+  $.ajax({
+    type: 'POST',
+    url: searchUrl,
+    contentType: 'application/json',
+    success: function() {console.log("Success!");},
+    error: failFunc
+  });
+});

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -27,9 +27,14 @@
         {% endif %}
       {% endfor %}
       <div class="row">
-        <div class="btn-group pull-right">
-          {{ search_form.submit(class_="btn btn-primary qc-search-submit") }}
-          <span id="qc-search-reset" class="btn btn-primary">Clear</span>
+        <div id="qc-search-interface" class="btn-group pull-right">
+          <button id="qc-search-btn" class="button btn btn-primary">
+            <span class="fas fa-search"></span> Search
+          </button>
+          <span id="qc-search-reset" class="btn btn-primary">
+            <span class="fas fa-backspace"></span>
+            Clear
+          </span>
         </div>
       </div>
     </form>

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -26,18 +26,18 @@
           </span>
         {% endif %}
       {% endfor %}
-      <div class="row">
-        <div id="qc-search-interface" class="btn-group pull-right">
-          <button id="qc-search-btn" class="button btn btn-primary">
-            <span class="fas fa-search"></span> Search
-          </button>
-          <span id="qc-search-reset" class="btn btn-primary">
-            <span class="fas fa-backspace"></span>
-            Clear
-          </span>
-        </div>
-      </div>
     </form>
+    <div class="row">
+      <div id="qc-search-interface" class="btn-group pull-right">
+        <button id="qc-search-btn" class="button btn btn-primary">
+          <span class="fas fa-search"></span> Search
+        </button>
+        <span id="qc-search-reset" class="btn btn-primary">
+          <span class="fas fa-backspace"></span>
+          Clear
+        </span>
+      </div>
+    </div>
   </div>
   <div class="col-xs-8">
     <div class="row">

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -1,0 +1,41 @@
+<!-- Provides a page users can use to search and download QC reviews -->
+{% extends 'base.html' %}
+{% include 'flash.html' %}
+
+{% block header_scripts %}
+  {{ super() }}
+  <script type="text/javascript">
+    // Variables needed by javascript functions
+    const csrfToken = "{{ csrf_token() }}";
+    const searchUrl = "{{ url_for('qc_search.lookup_data') }}";
+  </script>
+{% endblock%}
+
+{% block content %}
+<div class="row">
+  <div id="qc-search-terms-display" class="col-xs-6">
+    <form action="{{ url_for('qc_search.lookup_data') }}" method="post" id="qc-search-form">
+      {% for fname in search_form._fields %}
+        {% if fname not in ['submit', 'csrf_token'] %}
+          <span class="qc-search-label">
+            {{ search_form._fields[fname].label }}
+          </span>
+          <span class="qc-search-value">
+            {{ search_form._fields[fname] }}
+          </span>
+        {% endif %}
+      {% endfor %}
+      <div>
+        {{ search_form.submit(class_="btn btn-primary qc-search-submit") }}
+      </div>
+    </form>
+  </div>
+  <div id="qc-search-results-display" class="col-xs-6">
+    Results of search should go here.
+  </div>
+</div>
+{% endblock %}
+
+{% block footer_scripts %}
+  <script type="text/javascript" src="{{ url_for('qc_search.static', filename='qc-search.js') }}"></script>
+{% endblock %}

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -15,6 +15,7 @@
 <div class="row">
   <div id="qc-search-terms-display" class="col-xs-6">
     <form action="{{ url_for('qc_search.lookup_data') }}" method="post" id="qc-search-form">
+      {{ search_form.hidden_tag() }}
       {% for fname in search_form._fields %}
         {% if fname not in ['submit', 'csrf_token'] %}
           <span class="qc-search-label">

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -37,6 +37,9 @@
         <div class="col-sm-6">
           {{ search_form.include_new.label }}{{ search_form.include_new(class_="pull-right") }}
         </div>
+        <div class="col-sm-6">
+          {{ search_form.sort.label }}{{ search_form.sort(class_="pull-right") }}
+        </div>
       </div>
       <div class="row">
         <div class="col-sm-6">

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -9,6 +9,7 @@
     const csrfToken = "{{ csrf_token() }}";
     const searchUrl = "{{ url_for('qc_search.lookup_data') }}";
   </script>
+  <link href="{{ url_for('qc_search.static', filename='qc-search.css') }}" rel="stylesheet"/>
 {% endblock%}
 
 {% block content %}
@@ -16,16 +17,61 @@
   <div id="qc-search-terms-display" class="col-xs-4">
     <form action="{{ url_for('qc_search.lookup_data') }}" method="post" id="qc-search-form">
       {{ search_form.hidden_tag() }}
-      {% for fname in search_form._fields %}
-        {% if fname not in ['submit', 'csrf_token'] %}
-          <span class="qc-search-label">
-            {{ search_form._fields[fname].label }}
-          </span>
-          <span class="qc-search-value">
-            {{ search_form._fields[fname] }}
-          </span>
-        {% endif %}
-      {% endfor %}
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.approved.label }}{{ search_form.approved(class_="pull-right") }}
+        </div>
+        <div class="col-sm-6">
+          {{ search_form.blacklisted.label }}{{ search_form.blacklisted(class_="pull-right") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.flagged.label }}{{ search_form.flagged(class_="pull-right") }}
+        </div>
+        <div class="col-sm-6">
+          {{ search_form.include_phantoms.label }}{{ search_form.include_phantoms(class_="pull-right") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.include_new.label }}{{ search_form.include_new(class_="pull-right") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.study.label }}
+        </div>
+        <div class="col-sm-6">
+          {{ search_form.study }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.site.label }}
+        </div>
+        <div class="col-sm-6">
+          {{ search_form.site }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6">
+          {{ search_form.tag.label }}
+        </div>
+        <div class="col-sm-6">
+          {{ search_form.tag }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-12">
+          {{ search_form.comment.label(style="margin-top: 10px;") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-12">
+          {{ search_form.comment(style="width: 100%;") }}
+        </div>
+      </div>
     </form>
     <div class="row">
       <div id="qc-search-interface" class="btn-group pull-right">

--- a/dashboard/blueprints/qc_search/templates/qc_search.html
+++ b/dashboard/blueprints/qc_search/templates/qc_search.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 <div class="row">
-  <div id="qc-search-terms-display" class="col-xs-6">
+  <div id="qc-search-terms-display" class="col-xs-4">
     <form action="{{ url_for('qc_search.lookup_data') }}" method="post" id="qc-search-form">
       {{ search_form.hidden_tag() }}
       {% for fname in search_form._fields %}
@@ -26,13 +26,33 @@
           </span>
         {% endif %}
       {% endfor %}
-      <div>
-        {{ search_form.submit(class_="btn btn-primary qc-search-submit") }}
+      <div class="row">
+        <div class="btn-group pull-right">
+          {{ search_form.submit(class_="btn btn-primary qc-search-submit") }}
+          <span id="qc-search-reset" class="btn btn-primary">Clear</span>
+        </div>
       </div>
     </form>
   </div>
-  <div id="qc-search-results-display" class="col-xs-6">
-    Results of search should go here.
+  <div class="col-xs-8">
+    <div class="row">
+      <a id="qc-download" class="btn btn-primary pull-left" download="qc.csv">
+        <i class="fas fa-download"></i>Download
+      </a>
+    </div>
+    <div class="row">
+      <table id="qc-search-results-table" class="table table-striped" style="width: 100%;">
+        <thead>
+          <tr>
+            <th style="width: 40%;">Scan</th>
+            <th style="width: 10%;">Approved</th>
+            <th style="width: 50%;">Comment</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -21,7 +21,7 @@ def qc_search():
         (study.id, study.id) for study in current_user.get_studies()
     ]
     form.site.choices = [
-        (site, site) for site in current_user.get_sites()
+        (site, site) for site, *rest in current_user.get_sites()
     ]
     form.tag.choices = [
         (tag, tag) for tag, *rest in get_tags(current_user)

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -68,5 +68,6 @@ def get_tags(user):
         .filter(
             or_(StudyUser.site_id == None,
                 StudyUser.site_id == ExpectedScan.site_id))\
-        .with_entities(ExpectedScan.scantype_id)
+        .with_entities(ExpectedScan.scantype_id)\
+        .distinct()
     return query.all()

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -1,0 +1,48 @@
+from flask import render_template, request
+from flask_login import current_user, login_required
+from sqlalchemy import or_
+
+from . import checklist_bp
+from .forms import QcSearchForm
+from ...models import ExpectedScan, StudyUser
+from ...queries import get_scan_qc
+
+
+@checklist_bp.route('/', methods=["GET"])
+@login_required
+def qc_search():
+    """Get the QC review search form page.
+    """
+
+    form = QcSearchForm()
+    form.study.choices = [
+        (study.id, study.id) for study in current_user.get_studies()
+    ]
+    form.site.choices = [
+        (site, site) for site in current_user.get_sites()
+    ]
+    form.tag.choices = [
+        (tag, tag) for tag, *rest in get_tags(current_user)
+    ]
+
+    return render_template('qc_search.html', search_form=form)
+
+
+@checklist_bp.route('/submit-query', methods=["POST"])
+@login_required
+def lookup_data():
+    """Use AJAX to submit search terms and get a set of QC reviews.
+    """
+    return {}
+
+
+def get_tags(user):
+    query = ExpectedScan.query.join(
+        StudyUser,
+        StudyUser.study_id == ExpectedScan.study_id)\
+        .filter(StudyUser.user_id == user.id)\
+        .filter(
+            or_(StudyUser.site_id == None,
+                StudyUser.site_id == ExpectedScan.site_id))\
+        .with_entities(ExpectedScan.scantype_id)
+    return query.all()

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -44,10 +44,6 @@ def lookup_data():
     contents = get_form_contents(form)
     results = get_scan_qc(**contents)
 
-    print(f"Form contents = {contents}")
-    print(f"Search results = {results}")
-
-
     return jsonify(results)
 
 

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -38,10 +38,11 @@ def lookup_data():
     if not (form.is_submitted() or form.validate()):
         return jsonify(form.errors)
 
-    # This function needs to ensure that all terms submitted are actually
-    # accessible (e.g. study, site, tag are restricted to user permissions)
-
     contents = get_form_contents(form)
+
+    if not current_user.dashboard_admin:
+        contents["user_id"] = current_user.id
+
     results = get_scan_qc(**contents)
 
     return jsonify(results)

--- a/dashboard/blueprints/qc_search/views.py
+++ b/dashboard/blueprints/qc_search/views.py
@@ -21,7 +21,7 @@ def qc_search():
         (study.id, study.id) for study in current_user.get_studies()
     ]
     form.site.choices = [
-        (site, site) for site, *rest in current_user.get_sites()
+        (site, site) for site in current_user.get_sites()
     ]
     form.tag.choices = [
         (tag, tag) for tag, *rest in get_tags(current_user)

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -362,7 +362,7 @@ class User(PermissionMixin, UserMixin, TableMixin, db.Model):
                         sites = sites.union(study_site.study.sites)
                     else:
                         sites.add(study_site.site_id)
-        return list(sites)
+        return list(sorted(sites))
 
     def get_disabled_sites(self):
         """Get a dict of study IDs mapped to sites this user cant access
@@ -461,7 +461,7 @@ class AnonymousUser(PermissionMixin, AnonymousUserMixin):
         return Study.query.order_by(Study.id).all()
 
     def get_sites(self):
-        return [site.name for site in Site.query.all()]
+        return sorted([site.name for site in Site.query.all()])
 
     def get_disabled_sites(self):
         return {}

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -449,6 +449,8 @@ class AnonymousUser(PermissionMixin, AnonymousUserMixin):
     # 'account_active' status, be careful :)
 
     id = -1
+    dashboard_admin = False
+    account_active = False
     first_name = "Guest"
 
     def get_studies(self):

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -335,7 +335,10 @@ class User(PermissionMixin, UserMixin, TableMixin, db.Model):
         if self.dashboard_admin:
             studies = Study.query.order_by(Study.id).all()
         else:
-            studies = [su[0].study for su in self.studies.values()]
+            studies = sorted(
+                [su[0].study for su in self.studies.values()],
+                key=lambda x: x.id
+            )
         return studies
 
     def get_sites(self):
@@ -455,7 +458,7 @@ class AnonymousUser(PermissionMixin, AnonymousUserMixin):
     first_name = "Guest"
 
     def get_studies(self):
-        return Study.query.all()
+        return Study.query.order_by(Study.id).all()
 
     def get_sites(self):
         return [site.name for site in Site.query.all()]

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -348,7 +348,8 @@ class User(PermissionMixin, UserMixin, TableMixin, db.Model):
             list: A list of string site names.
         """
         if self.dashboard_admin:
-            sites = Site.query.with_entities(Site.name).all()
+            sites = [item[0]
+                     for item in Site.query.with_entities(Site.name).all()]
         else:
             sites = set()
             for study in self.studies:

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -295,7 +295,7 @@ def get_redcap_config(project, instrument, url, create=False):
 
 def get_scan_qc(approved=True, blacklisted=True, flagged=True,
                 study=None, site=None, tag=None, include_phantoms=False,
-                include_new=False, comment=None, user_id=None):
+                include_new=False, comment=None, user_id=None, sort=False):
 
     def get_list(input_var):
         return input_var if isinstance(input_var, list) else [input_var]
@@ -380,6 +380,9 @@ def get_scan_qc(approved=True, blacklisted=True, flagged=True,
                     )
                 )
             )
+
+    if sort:
+        query = query.order_by(Scan.name)
 
     # Restrict output values to only needed columns
     query = query.with_entities(Scan.name, ScanChecklist.approved,

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -296,10 +296,42 @@ def get_redcap_config(project, instrument, url, create=False):
 def get_scan_qc(approved=True, blacklisted=True, flagged=True,
                 study=None, site=None, tag=None, include_phantoms=False,
                 include_new=False, comment=None, user_id=None, sort=False):
-    ## !!!! Doc string should mention that using user_id doesnt take into
-    ## account when user is an admin. i.e. a dashboard admin will have no
-    ## records returned if they dont have entries in study_user, despite
-    ## global access
+    """Get a set of QC records matching the given search terms.
+
+    Args:
+        approved (bool, optional): If True scan QC records that have been
+            approved will be included in the result. Defaults to True.
+        blacklisted (bool, optional): If True scan QC records that have been
+            blacklisted will be included in the result. Defaults to True.
+        flagged (bool, optional): If True scan QC records that have been
+            flagged will be included in the result. Defaults to True.
+        study (str or list(str), optional): A study ID or list of study IDs
+            to restrict the search to. Defaults to None.
+        site (str or list(str), optional): A site ID or list of site IDs to
+            restrict the search to. Defaults to None.
+        tag (str or list(str), optional): A tag or list of tags to restrict
+            the search to. Defaults to None.
+        include_phantoms (bool, optional): Whether to include phantom QC
+            records in the result. Defaults to False.
+        include_new (bool, optional): Whether to include scans that have
+            not yet been reviewed in the output. Defaults to False.
+        comment (str, optional): A semi-colon delimited list of QC comments
+            to search for. Defaults to None.
+        user_id (int, optional): The ID of a valid user. If this is given
+            the records returned will be restricted to those that the
+            user has permission to view. Note that this does not take into
+            account permissions for dashboard admins. That is, if the user
+            ID given is for a dashboard admin, the results will be overly
+            restrictive.
+        sort (bool, optional): Whether to sort the results. Sorting is done
+            by scan name. Defaults to False.
+
+    Returns:
+        list(tuple): A list of tuples of the format
+            (scan name, status, comment), where 'status' is a boolean value
+            that represents whether the scan was approved or
+            flagged/blacklisted.
+    """
 
     def get_list(input_var):
         return input_var if isinstance(input_var, list) else [input_var]

--- a/dashboard/queries.py
+++ b/dashboard/queries.py
@@ -296,6 +296,10 @@ def get_redcap_config(project, instrument, url, create=False):
 def get_scan_qc(approved=True, blacklisted=True, flagged=True,
                 study=None, site=None, tag=None, include_phantoms=False,
                 include_new=False, comment=None, user_id=None, sort=False):
+    ## !!!! Doc string should mention that using user_id doesnt take into
+    ## account when user is an admin. i.e. a dashboard admin will have no
+    ## records returned if they dont have entries in study_user, despite
+    ## global access
 
     def get_list(input_var):
         return input_var if isinstance(input_var, list) else [input_var]
@@ -373,6 +377,7 @@ def get_scan_qc(approved=True, blacklisted=True, flagged=True,
                 study_timepoints_table.c.study == StudyUser.study_id)\
             .filter(
                 and_(
+                    ScanChecklist.user_id == StudyUser.user_id,
                     StudyUser.user_id == user_id,
                     or_(
                         StudyUser.site_id == None,

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -22,6 +22,9 @@
           </tr>
         </thead>
         <tbody>
+          <a class="btn btn-primary pull-right" style="margin-bottom: 5px;" href="{{ url_for('qc_search.qc_search') }}">
+            <span class="fas fa-search"></span> Search QC Records
+          </a>
           {% for study in studies %}
           <tr class="clickable-row" data-href="{{ url_for('main.study', study_id=study.id) }}">
             <td> {{ study.id }} </td>

--- a/dashboard/templates/study.html
+++ b/dashboard/templates/study.html
@@ -21,16 +21,27 @@ Most of the html in the divs is extracted into a snippet file and rendered
 
     <!-- The jumbotron page header -->
     <div class="jumbotron">
-      <h1>{{ study.name }}</h1>
-      {% if study.description %}
-        <p class="lead">{{ study.description }}</p>
-      {% endif %}
-        <p class="lead">
-          <ul class="list-inline">
-            <li>Human: <span class="badge">{{study.num_timepoints('human')}}</span></li>
-            <li>Phantom: <span class="badge">{{study.num_timepoints('phantom')}}</span></li>
-          </ul>
-        </p>
+      <div class="row">
+        <div class="col-sm-8">
+          <h1>{{ study.name }}</h1>
+          {% if study.description %}
+            <p class="lead">{{ study.description }}</p>
+          {% endif %}
+            <p class="lead">
+              <ul class="list-inline">
+                <li>Human: <span class="badge">{{study.num_timepoints('human')}}</span></li>
+                <li>Phantom: <span class="badge">{{study.num_timepoints('phantom')}}</span></li>
+              </ul>
+            </p>
+        </div>
+        <div class="col-sm-4">
+          <div class="btn-group pull-right">
+            <a class="btn btn-primary" href="{{ url_for('qc_search.qc_search') }}">
+              <span class="fas fa-search"></span> Search QC Records
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div class="row">

--- a/tests/blueprints/qc_search/test_forms.py
+++ b/tests/blueprints/qc_search/test_forms.py
@@ -1,21 +1,18 @@
-import pytest
-
-import dashboard
 import dashboard.blueprints.qc_search.forms as forms
 
 
-class TestGetFormContents:
+class TestGetSearchFormContents:
 
     def test_excludes_csrftoken_and_submit_fields(self, dash_app):
         with dash_app.test_request_context(
             "/submit-query", method="POST", data={}
         ):
             search_form = forms.QcSearchForm()
-            contents = forms.get_form_contents(search_form)
+            contents = forms.get_search_form_contents(search_form)
 
-        assert 'csrf_token' in search_form._fields
-        assert 'csrf_token' not in contents
-        assert 'submit' not in contents
+        assert "csrf_token" in search_form._fields
+        assert "csrf_token" not in contents
+        assert "submit" not in contents
 
     def test_parses_comments_field(self, dash_app):
         data = {"comment": "Corrupted scan;    Truncated"}
@@ -23,7 +20,7 @@ class TestGetFormContents:
             "/submit-query", method="POST", data=data
         ):
             search_form = forms.QcSearchForm()
-            contents = forms.get_form_contents(search_form)
+            contents = forms.get_search_form_contents(search_form)
 
         assert contents["comment"] == ["Corrupted scan", "Truncated"]
 

--- a/tests/blueprints/qc_search/test_forms.py
+++ b/tests/blueprints/qc_search/test_forms.py
@@ -1,0 +1,61 @@
+import pytest
+
+import dashboard
+import dashboard.blueprints.qc_search.forms as forms
+
+
+class TestGetFormContents:
+
+    def test_excludes_csrftoken_and_submit_fields(self, dash_app):
+        with dash_app.test_request_context(
+            "/submit-query", method="POST", data={}
+        ):
+            search_form = forms.QcSearchForm()
+            contents = forms.get_form_contents(search_form)
+
+        assert 'csrf_token' in search_form._fields
+        assert 'csrf_token' not in contents
+        assert 'submit' not in contents
+
+    def test_parses_comments_field(self, dash_app):
+        data = {"comment": "Corrupted scan;    Truncated"}
+        with dash_app.test_request_context(
+            "/submit-query", method="POST", data=data
+        ):
+            search_form = forms.QcSearchForm()
+            contents = forms.get_form_contents(search_form)
+
+        assert contents["comment"] == ["Corrupted scan", "Truncated"]
+
+
+class TestParseComment:
+
+    def test_empty_comment_returns_empty_list(self):
+        result = forms.parse_comment("")
+        assert result == []
+
+    def test_surrounding_whitespace_stripped_from_comments(self):
+        expected = ["Corrupted scan"]
+        result = forms.parse_comment("\nCorrupted scan")
+        assert result == expected
+
+        result = forms.parse_comment("Corrupted scan\t")
+        assert result == expected
+
+        result = forms.parse_comment("     Corrupted scan  ")
+        assert result == expected
+
+    def test_surrounding_quotes_stripped_from_comments(self):
+        expected = ["Corrupted"]
+        result = forms.parse_comment("'Corrupted'")
+        assert result == expected
+
+        result = forms.parse_comment('"Corrupted"')
+        assert result == expected
+
+        result = forms.parse_comment("'Corrupted")
+        assert result == expected
+
+    def test_multiple_comments_split_when_semicolon_separator_used(self):
+        result = forms.parse_comment("Truncated; Corrupted; bad file")
+        assert result == ["Truncated", "Corrupted", "bad file"]

--- a/tests/blueprints/qc_search/test_views.py
+++ b/tests/blueprints/qc_search/test_views.py
@@ -21,6 +21,16 @@ class TestGetTags:
         expected = self.get_tags_from_db()
         assert tags == sorted(expected)
 
+    def test_admin_user_has_access_to_all_tags(self):
+        admin = models.User.query.get(2)
+        tags = views.get_tags(admin)
+        expected = tests.utils.query_db(
+            "SELECT DISTINCT scantypes.tag"
+            "  FROM scantypes"
+            "  ORDER BY scantypes.tag"
+        )
+        assert tags == expected
+
     def get_tags_from_db(self):
         tags = tests.utils.query_db(
             "SELECT DISTINCT e.scantype"
@@ -37,9 +47,12 @@ def records(dash_db):
     """Adds some user records and tags for testing.
     """
     user = models.User("Donald", "Duck")
+    admin = models.User("Mickey", "Mouse", dashboard_admin=True)
     dash_db.session.add(user)
+    dash_db.session.add(admin)
     dash_db.session.commit()
     assert user.id == 1
+    assert admin.id == 2
 
     tests.utils.add_studies({
         "STUDY1": {

--- a/tests/blueprints/qc_search/test_views.py
+++ b/tests/blueprints/qc_search/test_views.py
@@ -1,0 +1,56 @@
+"""Tests for the views in blueprints/qc_search
+"""
+import pytest
+
+import tests.utils
+from dashboard import models
+from dashboard.blueprints.qc_search import views
+
+
+class TestGetTags:
+
+    def test_tags_are_not_duplicated(self):
+        user = models.User.query.get(1)
+        tags = views.get_tags(user)
+        expected = self.get_tags_from_db()
+        assert sorted(tags) == sorted(expected)
+
+    def test_tags_are_sorted(self):
+        user = models.User.query.get(1)
+        tags = views.get_tags(user)
+        expected = self.get_tags_from_db()
+        assert tags == sorted(expected)
+
+    def get_tags_from_db(self):
+        tags = tests.utils.query_db(
+            "SELECT DISTINCT e.scantype"
+            "  FROM study_users as su, expected_scans as e"
+            "  WHERE su.user_id = 1"
+            "    AND su.study = e.study"
+            "    AND (su.site = e.site OR su.site IS NULL)"
+        )
+        return tags
+
+
+@pytest.fixture(autouse=True)
+def records(dash_db):
+    """Adds some user records and tags for testing.
+    """
+    user = models.User("Donald", "Duck")
+    dash_db.session.add(user)
+    dash_db.session.commit()
+    assert user.id == 1
+
+    tests.utils.add_studies({
+        "STUDY1": {
+            "CMH": ["T1", "T2", "DTI60-1000"]
+        },
+        "STUDY2": {
+            "ABC": ["T1", "ASL", "DTI60-1000"]
+        }
+    })
+
+    user.add_studies({
+        "STUDY1": [],
+        "STUDY2": [],
+    })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,17 @@ def dash_app(request):
 
 @pytest.fixture(scope="function")
 def dash_db(dash_app):
+    yield from _make_db(dash_app)
+
+
+@pytest.fixture(scope="class")
+def read_only_db(dash_app):
+    """Use this fixture when tests in a class wont modify records.
+    """
+    yield from _make_db(dash_app)
+
+
+def _make_db(dash_app):
     with dash_app.app_context():
         dashboard.models.db.create_all()
         yield dashboard.models.db

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,6 +41,20 @@ class TestUser:
         result = admin.get_sites()
         assert all(isinstance(item, str) for item in result)
 
+    def test_get_sites_sorts_results_for_user(self):
+        user = models.User.query.get(1)
+        assert user.dashboard_admin is False
+
+        result = user.get_sites()
+        assert result == sorted(result)
+
+    def test_get_sites_sorts_results_for_admin(self):
+        user = models.User.query.get(2)
+        assert user.dashboard_admin is True
+
+        result = user.get_sites()
+        assert result == sorted(result)
+
     def test_get_studies_sorts_results_for_user(self):
         user = models.User.query.get(1)
         assert user.dashboard_admin is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,6 +41,31 @@ class TestUser:
         result = admin.get_sites()
         assert all(isinstance(item, str) for item in result)
 
+    def test_get_studies_sorts_results_for_user(self):
+        user = models.User.query.get(1)
+        assert user.dashboard_admin is False
+
+        result = [item.id for item in user.get_studies()]
+        expected = self.get_result(
+            "SELECT DISTINCT su.study"
+            "  FROM study_users as su"
+            "  WHERE su.user_id = 1"
+            "  ORDER BY su.study"
+        )
+        assert result == expected
+
+    def test_get_studies_sorts_results_for_admins(self):
+        admin = models.User.query.get(2)
+        assert admin.dashboard_admin is True
+
+        result = [item.id for item in admin.get_studies()]
+        expected = self.get_result(
+            "SELECT DISTINCT s.id"
+            "  FROM studies as s"
+            "  ORDER BY s.id"
+        )
+        assert result == expected
+
     def get_result(self, sql_query):
         return [item[0] for item in query_db(sql_query)]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,8 @@
 """
 
 import pytest
-import sqlalchemy
 
+from tests.utils import query_db, add_studies
 from dashboard import models
 
 
@@ -45,17 +45,6 @@ class TestUser:
         return [item[0] for item in query_db(sql_query)]
 
 
-def query_db(sql_query):
-    """Use raw SQL to query the database.
-    """
-    try:
-        records = models.db.session.execute(sql_query).fetchall()
-    except sqlalchemy.exc.ProgrammingError:
-        models.db.session.rollback()
-        raise
-    return records
-
-
 @pytest.fixture(autouse=True)
 def user_records(dash_db):
     """Adds some user records and access permissions for testing.
@@ -68,18 +57,18 @@ def user_records(dash_db):
     assert user.id == 1
     assert admin.id == 2
 
-    study1 = models.Study("STUDY1")
-    dash_db.session.add(study1)
-    study1.update_site("CMH", create=True)
-    study1.update_site("UTO", create=True)
-
-    study2 = models.Study("STUDY2")
-    dash_db.session.add(study2)
-    study2.update_site("CMH", create=True)
-
-    study3 = models.Study("STUDY3")
-    dash_db.session.add(study3)
-    study3.update_site("ABC", create=True)
+    add_studies({
+        "STUDY1": {
+            "CMH": [],
+            "UTO": []
+        },
+        "STUDY2": {
+            "CMH": []
+        },
+        "STUDY3": {
+            "ABC": []
+        }
+    })
 
     user.add_studies({
         "STUDY1": ["CMH"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,90 @@
+"""Tests for classes in dashboard.models
+"""
+
+import pytest
+import sqlalchemy
+
+from dashboard import models
+
+
+class TestUser:
+
+    def test_get_sites_returns_all_sites_avail_for_user(self):
+        user = models.User.query.get(1)
+        result = user.get_sites()
+        expected = self.get_result(
+            "SELECT DISTINCT ss.site"
+            "  FROM users as u, study_users as su, study_sites as ss"
+            "  WHERE u.id = su.user_id"
+            "    AND u.id = 1"
+            "    AND su.study = ss.study"
+            "    AND (su.site IS NULL OR su.site = ss.site)"
+        )
+        assert sorted(result) == sorted(expected)
+
+    def test_get_sites_doesnt_duplicate_site_names(self):
+        user = models.User.query.get(1)
+        result = user.get_sites()
+        expected = list(set(result))
+        assert sorted(result) == sorted(expected)
+
+    def test_get_sites_returns_list_of_strings_for_reg_user(self):
+        user = models.User.query.get(1)
+        result = user.get_sites()
+
+        assert all(isinstance(item, str) for item in result)
+
+    def test_get_sites_returns_list_of_strings_for_admin_user(self):
+        admin = models.User.query.get(2)
+        assert admin.dashboard_admin is True
+
+        result = admin.get_sites()
+        assert all(isinstance(item, str) for item in result)
+
+    def get_result(self, sql_query):
+        return [item[0] for item in query_db(sql_query)]
+
+
+def query_db(sql_query):
+    """Use raw SQL to query the database.
+    """
+    try:
+        records = models.db.session.execute(sql_query).fetchall()
+    except sqlalchemy.exc.ProgrammingError:
+        models.db.session.rollback()
+        raise
+    return records
+
+
+@pytest.fixture(autouse=True)
+def user_records(dash_db):
+    """Adds some user records and access permissions for testing.
+    """
+    user = models.User("Donald", "Duck")
+    admin = models.User("Mickey", "Mouse", dashboard_admin=True)
+    dash_db.session.add(user)
+    dash_db.session.add(admin)
+    dash_db.session.commit()
+    assert user.id == 1
+    assert admin.id == 2
+
+    study1 = models.Study("STUDY1")
+    dash_db.session.add(study1)
+    study1.update_site("CMH", create=True)
+    study1.update_site("UTO", create=True)
+
+    study2 = models.Study("STUDY2")
+    dash_db.session.add(study2)
+    study2.update_site("CMH", create=True)
+
+    study3 = models.Study("STUDY3")
+    dash_db.session.add(study3)
+    study3.update_site("ABC", create=True)
+
+    user.add_studies({
+        "STUDY1": ["CMH"],
+        "STUDY2": [],
+        "STUDY3": []
+    })
+
+    return dash_db

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -72,43 +72,224 @@ class TestGetStudies:
 
 class TestGetScanQc:
 
-    def test_finds_all_scan_qc_when_no_search_terms(self, records):
-        assert False
+    qc_entries = {
+        "approved": [
+            "STUDY1_CMH_0001_01_01_T1_10",
+            "STUDY2_CMH_4444_01_01_T2_04"
+        ],
+        "blacklisted": [
+            "STUDY1_UTO_0002_01_01_T1_10",
+            "STUDY2_CMH_4444_01_01_T2_03"
+        ],
+        "flagged": ["STUDY1_CMH_0001_01_01_DTI60-1000_11"],
+        "new": ["STUDY2_CMH_4444_01_01_RST_05"],
+        "approved_phantom": ["STUDY1_CMH_PHA_FBN190428_T1_01"],
+        "blacklist_phantom": ["STUDY2_CMH_PHA_FBN220920_T2_01"]
+    }
 
-    def test_finds_all_qc_matching_study(self, records):
-        assert False
+    def assert_all_entries_found(self, found, expected):
+        """Raises AssertionError if any 'expected' scans missing from 'found'.
+        """
+        scan_list = [item[0] for item in found]
+        for scan in expected:
+            assert scan in scan_list
 
-    def test_finds_all_qc_matching_studies(self, records):
-        assert False
+    def test_finds_all_reviewed_scans_when_no_search_terms(self):
+        result = dashboard.queries.get_scan_qc()
 
-    def test_finds_all_qc_matching_author(self, records):
-        assert False
+        expected = []
+        expected.extend(self.qc_entries["approved"])
+        expected.extend(self.qc_entries["flagged"])
+        expected.extend(self.qc_entries["blacklisted"])
 
-    def test_finds_all_qc_matching_authors(self, records):
-        assert False
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
 
-    def test_finds_all_qc_matching_tag(self, records):
-        assert False
+    def test_finds_all_except_approved_when_flag_is_false(self):
+        result = dashboard.queries.get_scan_qc(approved=False)
 
-    def test_finds_all_qc_matching_tags(self, records):
-        assert False
+        expected = []
+        expected.extend(self.qc_entries["flagged"])
+        expected.extend(self.qc_entries["blacklisted"])
 
-    def test_finds_approved_scans(self, records):
-        assert False
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
 
-    def test_finds_flagged_scans(self, records):
-        assert False
+    def test_finds_all_except_flagged_when_flag_is_false(self):
+        result = dashboard.queries.get_scan_qc(flagged=False)
 
-    def test_finds_blacklisted_scans(self, records):
-        assert False
+        expected = []
+        expected.extend(self.qc_entries["approved"])
+        expected.extend(self.qc_entries["blacklisted"])
 
-    def test_finds_unreviewed_scans_when_user_sets_all_flags_to_false(
-            self, records):
-        assert False
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
 
-    def test_finds_entries_matching_comment(self, records):
-        assert False
+    def test_finds_all_except_blacklisted_when_flag_is_false(self):
+        result = dashboard.queries.get_scan_qc(blacklisted=False)
 
-    @pytest.fixture
-    def records(self, dash_db):
-        return
+        expected = []
+        expected.extend(self.qc_entries["approved"])
+        expected.extend(self.qc_entries["flagged"])
+
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
+
+    def test_can_return_only_approved_entries(self):
+        result = dashboard.queries.get_scan_qc(
+            blacklisted=False, flagged=False)
+        expected = self.qc_entries["approved"]
+
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
+
+    def test_can_return_only_flagged_entries(self):
+        result = dashboard.queries.get_scan_qc(
+            approved=False, blacklisted=False)
+        expected = self.qc_entries["flagged"]
+
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
+
+    def test_can_return_only_blacklisted_entries(self):
+        result = dashboard.queries.get_scan_qc(
+            approved=False, flagged=False)
+        expected = self.qc_entries["blacklisted"]
+
+        assert len(result) == len(expected)
+        self.assert_all_entries_found(result, expected)
+
+    ##### Need to test combinations of options (sigh)
+    # approve = False, plus phantoms
+    # approve = False, plus new
+    # approve = False, flagged = False
+    # etc... All combinations for (approve, flag, blacklist) and (new, phantom)
+
+    # def test_finds_all_qc_matching_study(self, records):
+    #     assert False
+
+    # def test_finds_all_qc_matching_studies(self, records):
+    #     assert False
+    #
+    # def test_finds_all_qc_matching_author(self, records):
+    #     assert False
+    #
+    # def test_finds_all_qc_matching_authors(self, records):
+    #     assert False
+    #
+    # def test_finds_all_qc_matching_tag(self, records):
+    #     assert False
+    #
+    # def test_finds_all_qc_matching_tags(self, records):
+    #     assert False
+    #
+
+    #
+    # def test_finds_flagged_scans(self, records):
+    #     assert False
+    #
+    # def test_finds_blacklisted_scans(self, records):
+    #     assert False
+    #
+    # def test_finds_unreviewed_scans_when_user_sets_all_flags_to_false(
+    #         self, records):
+    #     assert False
+    #
+    # def test_finds_entries_matching_comment(self, records):
+    #     assert False
+
+    @pytest.fixture(autouse=True, scope="class")
+    def records(self, read_only_db):
+        """Create checklist entries to search.
+
+        The end result should be the following QC review data available to be
+        searched by tests:
+
+        ===================================  ======== ========== ========
+        Scan                                 Reviewer Status     Comment
+        ===================================  ======== ========== ========
+        STUDY1_CMH_0001_01_01_T1_10          1        approve
+        STUDY1_CMH_0001_01_01_DTI60-1000_11  1        flag       meh
+        STUDY1_UTO_0002_01_01_T1_10          2        blacklist  bad scan
+        STUDY1_CMH_PHA_FBN190428_T1_01       1        approve
+        STUDY2_CMH_4444_01_01_T2_03          1        blacklist  corrupted
+        STUDY2_CMH_4444_01_01_T2_04          2        approve
+        STUDY2_CMH_4444_01_01_RST_05
+        STUDY2_CMH_PHA_FBN220920_T2_01       2        blacklist  corrupted
+        """
+        user1 = dashboard.models.User('Jane', 'Doe')
+        user2 = dashboard.models.User('John', 'Doe')
+        read_only_db.session.add(user1)
+        read_only_db.session.add(user2)
+
+        read_only_db.session.add(dashboard.models.Scantype("T1"))
+        read_only_db.session.add(dashboard.models.Scantype("T2"))
+        read_only_db.session.add(dashboard.models.Scantype("DTI60-1000"))
+        read_only_db.session.add(dashboard.models.Scantype("RST"))
+
+        # Add the first study and mock data
+        study1 = dashboard.models.Study('STUDY1')
+        read_only_db.session.add(study1)
+        study1.update_site("CMH", create=True)
+        study1.update_site("UTO", create=True)
+        study1.update_scantype("CMH", "T1", create=True)
+        study1.update_scantype("CMH", "DTI60-1000", create=True)
+        study1.update_scantype("UTO", "T1", create=True)
+
+        tp1 = dashboard.models.Timepoint("STUDY1_CMH_0001_01", "CMH")
+        study1.add_timepoint(tp1)
+        tp1.add_session(1)
+        scan1 = tp1.sessions[1].add_scan(
+            "STUDY1_CMH_0001_01_01_T1_10", 10, "T1")
+        scan1.add_checklist_entry(user1.id, sign_off=True)
+        scan2 = tp1.sessions[1].add_scan(
+            "STUDY1_CMH_0001_01_01_DTI60-1000_11", 11, "DTI60-1000")
+        scan2.add_checklist_entry(user1.id, comment="meh",
+                                  sign_off=True)
+
+        tp2 = dashboard.models.Timepoint("STUDY1_UTO_0002_01", "UTO")
+        study1.add_timepoint(tp2)
+        tp2.add_session(1)
+        scan3 = tp1.sessions[1].add_scan(
+            "STUDY1_UTO_0002_01_01_T1_10", 10, "T1")
+        scan3.add_checklist_entry(user2.id, comment="bad scan", sign_off=False)
+
+        tp3 = dashboard.models.Timepoint("STUDY1_CMH_PHA_FBN190428", "CMH",
+                                         is_phantom=True)
+        study1.add_timepoint(tp3)
+        tp3.add_session(1)
+        scan4 = tp3.sessions[1].add_scan(
+            "STUDY1_CMH_PHA_FBN190428_T1_01", 1, "T1")
+        scan4.add_checklist_entry(user1.id, sign_off=True)
+
+        # Add the second study and mock data
+        study2 = dashboard.models.Study('STUDY2')
+        read_only_db.session.add(study2)
+        study2.update_site("CMH", create=True)
+        study2.update_scantype("CMH", "T2", create=True)
+        study2.update_scantype("CMH", "RST", create=True)
+
+        tp4 = dashboard.models.Timepoint("STUDY2_CMH_4444_01", "CMH")
+        study2.add_timepoint(tp4)
+        tp4.add_session(1)
+        scan5 = tp4.sessions[1].add_scan(
+            "STUDY2_CMH_4444_01_01_T2_03", 3, "T2"
+        )
+        scan5.add_checklist_entry(
+            user1.id, sign_off=False, comment="corrupted")
+        scan6 = tp4.sessions[1].add_scan(
+            "STUDY2_CMH_4444_01_01_T2_04", 4, "T2")
+        scan6.add_checklist_entry(user2.id, sign_off=True)
+        scan7 = tp4.sessions[1].add_scan(
+            "STUDY2_CMH_4444_01_01_RST_05", 5, "RST")
+
+        tp5 = dashboard.models.Timepoint(
+            "STUDY2_CMH_PHA_FBN220920", "CMH", is_phantom=True)
+        study2.add_timepoint(tp5)
+        tp5.add_session(1)
+        scan8 = tp5.sessions[1].add_scan(
+            "STUDY2_CMH_PHA_FBN220920_T2_01", 1, "T2")
+        scan8.add_checklist_entry(
+            user2.id, sign_off=False, comment="corrupted")
+
+        return read_only_db

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -343,7 +343,7 @@ class TestGetScanQc:
         self.assert_result_matches_expected(result, expected)
         # An extra check, to confirm no UTO records are found for this user
         for item in result:
-            assert '_UTO_' not in item[0]
+            assert "_UTO_" not in item[0]
 
     def test_returns_empty_list_when_user_access_rights_prevents_access(self):
         result = dashboard.queries.get_scan_qc(study=["STUDY3"], user_id=2)
@@ -416,8 +416,8 @@ class TestGetScanQc:
         STUDY2_CMH_PHA_FBN220920_T2_01       2        blacklist  corrupted
         STUDY3_ABC_1234_01_01_DTI60-1000_11  1        approve
         """
-        user1 = dashboard.models.User('Jane', 'Doe')
-        user2 = dashboard.models.User('John', 'Doe')
+        user1 = dashboard.models.User("Jane", "Doe")
+        user2 = dashboard.models.User("John", "Doe")
         read_only_db.session.add(user1)
         read_only_db.session.add(user2)
 
@@ -427,7 +427,7 @@ class TestGetScanQc:
         read_only_db.session.add(dashboard.models.Scantype("RST"))
 
         # Add the first study and mock data
-        study1 = dashboard.models.Study('STUDY1')
+        study1 = dashboard.models.Study("STUDY1")
         read_only_db.session.add(study1)
         study1.update_site("CMH", create=True)
         study1.update_site("UTO", create=True)
@@ -462,7 +462,7 @@ class TestGetScanQc:
         scan4.add_checklist_entry(user1.id, sign_off=True)
 
         # Add the second study and mock data
-        study2 = dashboard.models.Study('STUDY2')
+        study2 = dashboard.models.Study("STUDY2")
         read_only_db.session.add(study2)
         study2.update_site("CMH", create=True)
         study2.update_scantype("CMH", "T2", create=True)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -361,6 +361,20 @@ class TestGetScanQc:
 
         assert result == expected == []
 
+    def test_sorts_output_by_scan_when_flag_given(self):
+        result = dashboard.queries.get_scan_qc(sort=True)
+        expected = self.query_db(
+            "SELECT s.name, sc.signed_off, sc.comment"
+            "  FROM scans as s, scan_checklist as sc, timepoints as t"
+            "  WHERE s.id = sc.scan_id"
+            "      AND t.name = s.timepoint"
+            "      AND t.is_phantom = false"
+            "  ORDER BY s.name;"
+        )
+
+        result_names = [item[0] for item in result]
+        assert result_names == expected
+
     def query_db(self, sql_query):
         try:
             records = dashboard.models.db.session.execute(sql_query).fetchall()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,6 +1,7 @@
 import pytest
-import sqlalchemy
 
+from tests.utils import (add_studies, add_scans, query_db, Session, Scan,
+                         QcReview)
 import dashboard.queries
 
 
@@ -75,7 +76,7 @@ class TestGetScanQc:
 
     def test_finds_all_reviewed_human_scans_when_no_search_terms(self):
         result = dashboard.queries.get_scan_qc()
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -87,7 +88,7 @@ class TestGetScanQc:
 
     def test_finds_all_human_qc_except_approved_when_flag_is_false(self):
         result = dashboard.queries.get_scan_qc(approved=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -100,7 +101,7 @@ class TestGetScanQc:
 
     def test_finds_all_human_qc_except_flagged_when_flag_is_false(self):
         result = dashboard.queries.get_scan_qc(flagged=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -113,7 +114,7 @@ class TestGetScanQc:
 
     def test_finds_all_human_qc_except_blacklisted_when_flag_is_false(self):
         result = dashboard.queries.get_scan_qc(blacklisted=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -127,7 +128,7 @@ class TestGetScanQc:
     def test_can_return_only_approved_entries(self):
         result = dashboard.queries.get_scan_qc(
             blacklisted=False, flagged=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -141,7 +142,7 @@ class TestGetScanQc:
     def test_can_return_only_flagged_entries(self):
         result = dashboard.queries.get_scan_qc(
             approved=False, blacklisted=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -155,7 +156,7 @@ class TestGetScanQc:
     def test_can_return_only_blacklisted_entries(self):
         result = dashboard.queries.get_scan_qc(
             approved=False, flagged=False)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -168,7 +169,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_study(self):
         result = dashboard.queries.get_scan_qc(study="STUDY1")
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st"
@@ -183,7 +184,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_studies(self):
         result = dashboard.queries.get_scan_qc(study=["STUDY1", "STUDY3"])
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st"
@@ -198,7 +199,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_site(self):
         result = dashboard.queries.get_scan_qc(site="CMH")
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -211,7 +212,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_sites(self):
         result = dashboard.queries.get_scan_qc(site=["UTO", "ABC"])
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -224,7 +225,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_tag(self):
         result = dashboard.queries.get_scan_qc(tag="T2")
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -237,7 +238,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matching_tags(self):
         result = dashboard.queries.get_scan_qc(tag=["T1", "DTI60-1000"])
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -250,7 +251,7 @@ class TestGetScanQc:
 
     def test_finds_qc_matching_provided_comment(self):
         result = dashboard.queries.get_scan_qc(comment="bad scan")
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -263,7 +264,7 @@ class TestGetScanQc:
 
     def test_finds_qc_matching_comment_when_case_differs(self):
         result = dashboard.queries.get_scan_qc(comment="Bad Scan")
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             " FROM scans as s, scan_checklist as sc"
             " WHERE s.id = sc.scan_id AND sc.comment ilike 'Bad Scan';"
@@ -273,7 +274,7 @@ class TestGetScanQc:
 
     def test_finds_all_qc_matches_when_multiple_comments_given(self):
         result = dashboard.queries.get_scan_qc(comment=["meh", "bad scan"])
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             " FROM scans as s, scan_checklist as sc"
             " WHERE s.id = sc.scan_id "
@@ -284,7 +285,7 @@ class TestGetScanQc:
 
     def test_finds_unreviewed_scans_when_flag_is_true(self):
         result = dashboard.queries.get_scan_qc(include_new=True)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s"
             "  JOIN timepoints as t on t.name = s.timepoint"
@@ -296,7 +297,7 @@ class TestGetScanQc:
 
     def test_finds_records_for_phantoms_when_flag_is_true(self):
         result = dashboard.queries.get_scan_qc(include_phantoms=True)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             " FROM scans as s, scan_checklist as sc"
             " WHERE s.id = sc.scan_id;"
@@ -306,7 +307,7 @@ class TestGetScanQc:
 
     def test_finds_records_when_user_id_given(self):
         result = dashboard.queries.get_scan_qc(user_id=2)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
@@ -325,7 +326,7 @@ class TestGetScanQc:
     def test_limits_records_based_on_user_access_rights_when_user_id_given(
             self):
         result = dashboard.queries.get_scan_qc(site=["CMH", "UTO"], user_id=1)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
@@ -347,7 +348,7 @@ class TestGetScanQc:
 
     def test_returns_empty_list_when_user_access_rights_prevents_access(self):
         result = dashboard.queries.get_scan_qc(study=["STUDY3"], user_id=2)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name"
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
@@ -366,7 +367,7 @@ class TestGetScanQc:
 
     def test_sorts_output_by_scan_when_flag_given(self):
         result = dashboard.queries.get_scan_qc(sort=True)
-        expected = self.query_db(
+        expected = self.get_records(
             "SELECT s.name, sc.signed_off, sc.comment"
             "  FROM scans as s, scan_checklist as sc, timepoints as t"
             "  WHERE s.id = sc.scan_id"
@@ -378,14 +379,8 @@ class TestGetScanQc:
         result_names = [item[0] for item in result]
         assert result_names == expected
 
-    def query_db(self, sql_query):
-        try:
-            records = dashboard.models.db.session.execute(sql_query).fetchall()
-        except sqlalchemy.exc.ProgrammingError:
-            # A test gave bad sql, rollback or all tests after fail
-            dashboard.models.db.session.rollback()
-            raise
-        return [item[0] for item in records]
+    def get_records(self, sql_query):
+        return [item[0] for item in query_db(sql_query)]
 
     def assert_result_matches_expected(self, result, expected):
         # Ensure there are no extra entries
@@ -420,90 +415,62 @@ class TestGetScanQc:
         user2 = dashboard.models.User("John", "Doe")
         read_only_db.session.add(user1)
         read_only_db.session.add(user2)
+        read_only_db.session.commit()
 
-        read_only_db.session.add(dashboard.models.Scantype("T1"))
-        read_only_db.session.add(dashboard.models.Scantype("T2"))
-        read_only_db.session.add(dashboard.models.Scantype("DTI60-1000"))
-        read_only_db.session.add(dashboard.models.Scantype("RST"))
+        studies = add_studies({
+            "STUDY1": {
+                "CMH": ["T1", "DTI60-1000"],
+                "UTO": ["T1"]
+            },
+            "STUDY2": {
+                "CMH": ["T2", "RST"]
+            },
+            "STUDY3": {
+                "ABC": ["DTI60-1000"]
+            }
+        })
 
-        # Add the first study and mock data
-        study1 = dashboard.models.Study("STUDY1")
-        read_only_db.session.add(study1)
-        study1.update_site("CMH", create=True)
-        study1.update_site("UTO", create=True)
-        study1.update_scantype("CMH", "T1", create=True)
-        study1.update_scantype("CMH", "DTI60-1000", create=True)
-        study1.update_scantype("UTO", "T1", create=True)
+        scans = {
+            "STUDY1": {
+                Session("STUDY1_CMH_0001_01", "CMH", 1): [
+                    Scan("STUDY1_CMH_0001_01_01_T1_10", 10, "T1",
+                         QcReview(user1.id, True)),
+                    Scan("STUDY1_CMH_0001_01_01_DTI60-1000_11", 11,
+                         "DTI60-1000", QcReview(user1.id, True, "meh")),
+                ],
+                Session("STUDY1_UTO_0002_01", "UTO", 1): [
+                    Scan("STUDY1_UTO_0002_01_01_T1_10", 10, "T1",
+                         QcReview(user2.id, False, "bad scan")),
+                ],
+                Session("STUDY1_CMH_PHA_FBN190428", "CMH", 1, True): [
+                    Scan("STUDY1_CMH_PHA_FBN190428_T1_01", 1, "T1",
+                         QcReview(user1.id, True))
+                ]
+            },
+            "STUDY2": {
+                Session("STUDY2_CMH_4444_01", "CMH", 1): [
+                    Scan("STUDY2_CMH_4444_01_01_T2_03", 3, "T2",
+                         QcReview(user1.id, False, "corrupted")),
+                    Scan("STUDY2_CMH_4444_01_01_T2_04", 4, "T2",
+                         QcReview(user2.id, True)),
+                    Scan("STUDY2_CMH_4444_01_01_RST_05", 5, "RST")
+                ],
+                Session("STUDY2_CMH_PHA_FBN220920", "CMH", 1, True): [
+                    Scan("STUDY2_CMH_PHA_FBN220920_T2_01", 1, "T2",
+                         QcReview(user2.id, False, "corrupted"))
+                ],
+            },
+            "STUDY3": {
+                Session("STUDY3_ABC_1234_01", "ABC", 1): [
+                    Scan("STUDY3_ABC_1234_01_01_DTI60-1000_11", 11,
+                         "DTI60-1000", QcReview(user1.id, True))
+                ]
+            }
+        }
 
-        tp1 = dashboard.models.Timepoint("STUDY1_CMH_0001_01", "CMH")
-        study1.add_timepoint(tp1)
-        tp1.add_session(1)
-        scan1 = tp1.sessions[1].add_scan(
-            "STUDY1_CMH_0001_01_01_T1_10", 10, "T1")
-        scan1.add_checklist_entry(user1.id, sign_off=True)
-        scan2 = tp1.sessions[1].add_scan(
-            "STUDY1_CMH_0001_01_01_DTI60-1000_11", 11, "DTI60-1000")
-        scan2.add_checklist_entry(user1.id, comment="meh",
-                                  sign_off=True)
+        for study in studies:
+            add_scans(study, scans[study.id])
 
-        tp2 = dashboard.models.Timepoint("STUDY1_UTO_0002_01", "UTO")
-        study1.add_timepoint(tp2)
-        tp2.add_session(1)
-        scan3 = tp2.sessions[1].add_scan(
-            "STUDY1_UTO_0002_01_01_T1_10", 10, "T1")
-        scan3.add_checklist_entry(user2.id, comment="bad scan", sign_off=False)
-
-        tp3 = dashboard.models.Timepoint("STUDY1_CMH_PHA_FBN190428", "CMH",
-                                         is_phantom=True)
-        study1.add_timepoint(tp3)
-        tp3.add_session(1)
-        scan4 = tp3.sessions[1].add_scan(
-            "STUDY1_CMH_PHA_FBN190428_T1_01", 1, "T1")
-        scan4.add_checklist_entry(user1.id, sign_off=True)
-
-        # Add the second study and mock data
-        study2 = dashboard.models.Study("STUDY2")
-        read_only_db.session.add(study2)
-        study2.update_site("CMH", create=True)
-        study2.update_scantype("CMH", "T2", create=True)
-        study2.update_scantype("CMH", "RST", create=True)
-
-        tp4 = dashboard.models.Timepoint("STUDY2_CMH_4444_01", "CMH")
-        study2.add_timepoint(tp4)
-        tp4.add_session(1)
-        scan5 = tp4.sessions[1].add_scan(
-            "STUDY2_CMH_4444_01_01_T2_03", 3, "T2"
-        )
-        scan5.add_checklist_entry(
-            user1.id, sign_off=False, comment="corrupted")
-        scan6 = tp4.sessions[1].add_scan(
-            "STUDY2_CMH_4444_01_01_T2_04", 4, "T2")
-        scan6.add_checklist_entry(user2.id, sign_off=True)
-        tp4.sessions[1].add_scan("STUDY2_CMH_4444_01_01_RST_05", 5, "RST")
-
-        tp5 = dashboard.models.Timepoint(
-            "STUDY2_CMH_PHA_FBN220920", "CMH", is_phantom=True)
-        study2.add_timepoint(tp5)
-        tp5.add_session(1)
-        scan8 = tp5.sessions[1].add_scan(
-            "STUDY2_CMH_PHA_FBN220920_T2_01", 1, "T2")
-        scan8.add_checklist_entry(
-            user2.id, sign_off=False, comment="corrupted")
-
-        # Add a third study and mock data
-        study3 = dashboard.models.Study("STUDY3")
-        read_only_db.session.add(study3)
-        study3.update_site("ABC", create=True)
-        study3.update_scantype("ABC", "DTI60-1000", create=True)
-
-        tp6 = dashboard.models.Timepoint("STUDY3_ABC_1234_01", "ABC")
-        study3.add_timepoint(tp6)
-        tp6.add_session(1)
-        scan9 = tp6.sessions[1].add_scan(
-            "STUDY3_ABC_1234_01_01_DTI60-1000_11", 11, "DTI60-1000")
-        scan9.add_checklist_entry(user1.id, sign_off=True)
-
-        # Give test users limited study access
         user1.add_studies({
             "STUDY1": ["CMH"],
             "STUDY2": [],

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -68,3 +68,47 @@ class TestGetStudies:
 
         dash_db.session.commit()
         return [study1, study2, study3]
+
+
+class TestGetScanQc:
+
+    def test_finds_all_scan_qc_when_no_search_terms(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_study(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_studies(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_author(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_authors(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_tag(self, records):
+        assert False
+
+    def test_finds_all_qc_matching_tags(self, records):
+        assert False
+
+    def test_finds_approved_scans(self, records):
+        assert False
+
+    def test_finds_flagged_scans(self, records):
+        assert False
+
+    def test_finds_blacklisted_scans(self, records):
+        assert False
+
+    def test_finds_unreviewed_scans_when_user_sets_all_flags_to_false(
+            self, records):
+        assert False
+
+    def test_finds_entries_matching_comment(self, records):
+        assert False
+
+    @pytest.fixture
+    def records(self, dash_db):
+        return

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -311,12 +311,13 @@ class TestGetScanQc:
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
             "  WHERE s.id = sc.scan_id"
+            "      AND sc.user_id = 2"
+            "      AND sc.user_id = su.user_id"
             "      AND t.name = s.timepoint"
             "      AND st.timepoint = t.name"
             "      AND t.is_phantom = false"
             "      AND st.study = su.study"
-            "      AND (su.site IS NULL OR su.site = t.site)"
-            "      AND su.user_id = 2;"
+            "      AND (su.site IS NULL OR su.site = t.site);"
         )
 
         self.assert_result_matches_expected(result, expected)
@@ -329,13 +330,14 @@ class TestGetScanQc:
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
             "  WHERE s.id = sc.scan_id"
+            "      AND su.user_id = 1"
+            "      AND sc.user_id = su.user_id"
             "      AND t.name = s.timepoint"
             "      AND st.timepoint = t.name"
             "      AND t.is_phantom = false"
             "      AND t.site in ('CMH', 'UTO')"
             "      AND st.study = su.study"
-            "      AND (su.site IS NULL OR su.site = t.site)"
-            "      AND su.user_id = 1;"
+            "      AND (su.site IS NULL OR su.site = t.site);"
         )
 
         self.assert_result_matches_expected(result, expected)
@@ -350,13 +352,14 @@ class TestGetScanQc:
             "  FROM scans as s, scan_checklist as sc, timepoints as t, "
             "      study_timepoints as st, study_users as su"
             "  WHERE s.id = sc.scan_id"
+            "      AND su.user_id = 2"
+            "      AND sc.user_id = su.user_id"
             "      AND t.name = s.timepoint"
             "      AND st.timepoint = t.name"
             "      AND t.is_phantom = false"
             "      AND st.study = 'STUDY3'"
             "      AND st.study = su.study"
-            "      AND (su.site IS NULL OR su.site = t.site)"
-            "      AND su.user_id = 2;"
+            "      AND (su.site IS NULL OR su.site = t.site);"
         )
 
         assert result == expected == []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,102 @@
+"""Re-usable functions to help with testing.
+"""
+from collections import namedtuple
+import sqlalchemy
+
+from dashboard import models
+
+Session = namedtuple("Session", "name site num is_phantom", defaults=[False])
+Scan = namedtuple("Scan", "name series tag review",
+                  defaults=[None])
+QcReview = namedtuple("QcReview", "uid sign_off comment", defaults=[None])
+
+
+def add_studies(study_conf):
+    """Add studies to the test database.
+
+    Args:
+        study_conf (:obj:`dict`): A dictionary containing study IDs as
+            keys, each of which has its own dictionary of sites mapped to
+            the scan types for the site. E.g.
+                {"STUDY1": {
+                    "CMH": ["T1", "T2"]
+                    "UTO": ["DTI60-1000"]
+                  },
+                  "STUDY2": {
+                    "ABC": ["T1", "ASL"]
+                  }
+                }
+
+    Returns:
+        list: a list of dashboard.models.Study records for each created
+            study.
+    """
+    studies = []
+    for study_id in study_conf:
+        study = models.Study(study_id)
+        models.db.session.add(study)
+        studies.append(study)
+
+        for site in study_conf[study_id]:
+            study.update_site(site, create=True)
+
+            for tag in study_conf[study_id][site]:
+                if not models.Scantype.query.get(tag):
+                    models.db.session.add(models.Scantype(tag))
+                study.update_scantype(site, tag, create=True)
+
+    return studies
+
+
+def add_scans(study, scans):
+    """Add scans (and their timepoint + session records) to the test database.
+
+    Args:
+        study (:obj:`dashboard.models.Study`): A study record from the
+            database. All created scans will be added to this study.
+        scans (:obj:`dict`): A dictionary of Session named tuples mapped
+            to a list of Scan named tuples. E.g.
+                {
+                  Session("STUDY1_CMH_0001_01", "CMH", 1): [
+                      Scan("STUDY1_CMH_0001_01_01_T1_03", 3, "T1")
+                ]}
+            All scans and their parent sessions and timepoints will be
+            created.
+
+    Returns:
+        list: A list of :obj:`dashboard.models.Scan` objects that have
+            been created in the test database.
+    """
+    output = []
+    for session in scans:
+        timepoint = models.Timepoint(session.name, session.site)
+        study.add_timepoint(timepoint)
+        timepoint.add_session(session.num)
+
+        for item in scans[session]:
+            scan = timepoint.sessions[session.num].add_scan(
+                item.name, item.series, item.tag)
+            if item.review:
+                review = item.review
+                scan.add_checklist_entry(
+                    review.uid, review.comment, review.sign_off)
+            output.append(scan)
+
+    return output
+
+
+def query_db(sql_query):
+    """Submit a raw sql query to the database.
+
+    Args:
+        sql_query (str): The sql query to submit.
+
+    Result:
+        list: A list of tuples containing the result.
+    """
+    try:
+        records = models.db.session.execute(sql_query).fetchall()
+    except sqlalchemy.exc.ProgrammingError:
+        models.db.session.rollback()
+        raise
+    return records


### PR DESCRIPTION
This PR adds the 'qc_search' blueprint which provides a page for searching through QC records.
![image](https://user-images.githubusercontent.com/10541496/196514818-55727c67-4993-4fa7-b1ea-b70b13fb8eac.png)

Searches are submitted by ajax and results presented like the below image
![image](https://user-images.githubusercontent.com/10541496/196515100-9abf47df-c9bd-437e-a0d0-9e5813ddaecf.png)

It also provides a download button for downloading the results as a json file. Links to this new search page are on the main dashboard landing page, and in the header of each study's overview page. 
![image](https://user-images.githubusercontent.com/10541496/196515363-be7aecd0-0972-4c5c-bc5d-d407556deea6.png)
![image](https://user-images.githubusercontent.com/10541496/196515421-19656237-994c-494c-80f7-00fb062626c4.png)

I've also added tests for much of the newly added code.

@jerdra, @edickie Any comments RE: the user interface changes? 