### PR TITLE
[ENH] Display conversion error messages on main timepoint page

### DIFF
--- a/dashboard/blueprints/timepoints/templates/sessions/conversion_error.html
+++ b/dashboard/blueprints/timepoints/templates/sessions/conversion_error.html
@@ -1,0 +1,12 @@
+<div id="conversion_error_details-{{ scan.id }}" class="panel panel-danger" style="margin-top: 15px;">
+<div class="panel-heading collapsible-heading" data-toggle="collapse" data-target="#ConvErrMessage-{{ scan.id }}">
+    <h3 class="panel-title chevron-toggle">
+    <i class="fas fa-exclamation-triangle"></i>
+    DICOM conversion Error
+    <i class="fas fa-exclamation-triangle"></i>
+    </h3>
+</div>
+<div class="panel-body collapse in" id="ConvErrMessage-{{ scan.id }}">
+    {{ scan.conv_errors.replace("\n", "<br>")|safe }}
+</div>
+</div>

--- a/dashboard/blueprints/timepoints/templates/sessions/main.html
+++ b/dashboard/blueprints/timepoints/templates/sessions/main.html
@@ -51,6 +51,9 @@
       {% for scan in session.scans %}
         <h2 id="{{ scan.name }}">{{ scan.name }}</h2>
         {% include 'sessions/qc_header.html' %}
+        {% if scan.conv_errors %}
+          {% include 'sessions/conversion_error.html' %}
+        {% endif %}
         {% if scan.name in manifests[session.num] %}
           {% for image in manifests[session.num][scan.name] %}
             {% set settings = manifests[session.num][scan.name][image] %}

--- a/dashboard/blueprints/timepoints/templates/sessions/scan_table.html
+++ b/dashboard/blueprints/timepoints/templates/sessions/scan_table.html
@@ -62,7 +62,7 @@
             {% endif %}
             {% if scan.conv_errors %}
               <span class="badge" style="background-color: #000000;">
-                dcm2niix error
+                conversion error
               </span>
             {% endif %}
             {% if scan.tag not in counts %}

--- a/dashboard/models/models.py
+++ b/dashboard/models/models.py
@@ -1893,6 +1893,8 @@ class Scan(TableMixin, db.Model):
                                        "{}".format(self, json_file, e))
 
     def add_error(self, error_message):
+        if isinstance(error_message, list):
+            error_message = "\n".join(error_message)
         self.conv_errors = error_message
         try:
             self.save()


### PR DESCRIPTION
This PR adds the dcm2niix/dcm2bids conversion errors to the main timepoint page. The `session/conversion_error.hml` file is largely duplicating `blueprints/scan/template/snips/dcm2niix_details.html`, but that file will be removed in the future due to the scan page being phased out.